### PR TITLE
Add tooltips for decisions to upgrade CoTs

### DIFF
--- a/decisions/upgrade_trade_center.txt
+++ b/decisions/upgrade_trade_center.txt
@@ -18,6 +18,7 @@ country_decisions = {
 			is_at_war = no
 		}
 		effect = {
+			custom_tooltip = upgrade_1_to_2_tooltip
 			hidden_effect = {
 				set_variable = {
 					which = ptPower
@@ -53,31 +54,31 @@ country_decisions = {
 						log = "find [This.GetName] [This.ptPower.GetValue]"
 					}
 				}
-			}
-			event_target:ptpFlag = {
-				add_center_of_trade_level = 1
-					hidden_effect = {
-						owner = {
-							export_to_variable = {
-								which = cotuCost
-								value = modifier:center_of_trade_upgrade_cost
-							}
-							change_variable = {
-								which = cotuCost
-								value = 1
-							}
-							multiply_variable = {
-								which = cotuCost
-								value = -200
-							}
-							add_power_effect = { #command_variable_effect
-								variable = cotuCost
-								command = add_treasury
+				event_target:ptpFlag = {
+					add_center_of_trade_level = 1
+						hidden_effect = {
+							owner = {
+								export_to_variable = {
+									which = cotuCost
+									value = modifier:center_of_trade_upgrade_cost
+								}
+								change_variable = {
+									which = cotuCost
+									value = 1
+								}
+								multiply_variable = {
+									which = cotuCost
+									value = -200
+								}
+								add_power_effect = { #command_variable_effect
+									variable = cotuCost
+									command = add_treasury
+								}
 							}
 						}
-					}
-				log = "final [This.GetName] [This.ptPower.GetValue]"
-			}
+					log = "final [This.GetName] [This.ptPower.GetValue]"
+				}
+			}	
 		}
 		ai_will_do = {
 			factor = 1
@@ -151,6 +152,7 @@ country_decisions = {
 			else_if = { limit = { NOT = { num_of_owned_provinces_with = { value =	42	province_has_center_of_trade_of_level = 3 } } } num_of_merchants =	42	}
 		}
 		effect = {
+			custom_tooltip = upgrade_2_to_3_tooltip
 			hidden_effect = {
 				set_variable = {
 					which = ptPower
@@ -188,30 +190,30 @@ country_decisions = {
 						log = "find [This.GetName] [This.ptPower.GetValue]"
 					}
 				}
-			}
-			event_target:ptpFlag = {
-				add_center_of_trade_level = 1
-					hidden_effect = {
-						owner = {
-							export_to_variable = {
-								which = cotuCost
-								value = modifier:center_of_trade_upgrade_cost
-							}
-							change_variable = {
-								which = cotuCost
-								value = 1
-							}
-							multiply_variable = {
-								which = cotuCost
-								value = -1000
-							}
-							add_power_effect = { #command_variable_effect
-								variable = cotuCost
-								command = add_treasury
+				event_target:ptpFlag = {
+					add_center_of_trade_level = 1
+						hidden_effect = {
+							owner = {
+								export_to_variable = {
+									which = cotuCost
+									value = modifier:center_of_trade_upgrade_cost
+								}
+								change_variable = {
+									which = cotuCost
+									value = 1
+								}
+								multiply_variable = {
+									which = cotuCost
+									value = -1000
+								}
+								add_power_effect = { #command_variable_effect
+									variable = cotuCost
+									command = add_treasury
+								}
 							}
 						}
-					}
-				log = "final [This.GetName] [This.ptPower.GetValue]"
+					log = "final [This.GetName] [This.ptPower.GetValue]"
+				}
 			}
 		}
 		ai_will_do = {

--- a/localisation/excel_l_english.yml
+++ b/localisation/excel_l_english.yml
@@ -211,3 +211,10 @@
  cb_color_93:0 "Misplaced Border
  cb_color_94_desc:0 "People have been complaining about Unresolved Margins, Color disputes, Precarious Perimeters and a Chroninc Chromatic Conflict between out nations. It needs to be resolved on the battlefield."
  cb_color_94:0 "Misplaced Border
+ # Tooltips for decisions to upgrade Trade Centers
+ upgrade_1_to_2_title: "Upgrade a Center of Trade to Level 2"
+ upgrade_1_to_2_desc: "It is currently possible to upgrade one of our Centers of Trade to level 2. You can either choose the province manually, or use this convenient decision."
+ upgrade_1_to_2_tooltip: "Upgrade a §YLevel 1§! Center of Trade to §YLevel 2§!.\nThis will cost §Y200§! ducats (subject to modifiers).\nThe script will choose the Center of Trade with the most provincial trade power."
+ upgrade_2_to_3_title: "Upgrade a Center of Trade to Level 3"
+ upgrade_2_to_3_desc: "It is currently possible to upgrade one of our Centers of Trade to level 3. You can either choose the province manually, or use this convenient decision."
+ upgrade_2_to_3_tooltip: "Upgrade a §YLevel 2§! Center of Trade to §YLevel 3§!.\nThis will cost §Y1000§! ducats (subject to modifiers).\nThe script will choose the Center of Trade with the most provincial trade power."


### PR DESCRIPTION
Moves the effects of upgrade_1_to_2 and upgrade_2_to_3 into hidden_effect (to clear up the tooltips)
Adds fancy tooltips for these decisions