### PR TITLE
Add explanation of empowered edicts to building tooltips

### DIFF
--- a/localisation/replace/IV_replace_l_english.yml
+++ b/localisation/replace/IV_replace_l_english.yml
@@ -31,4 +31,8 @@
  idea_var_advisor_30:0 "Militarist £mil£"
  idea_var_advisor_31:0 "Absolutist £adm£"
  idea_var_advisor_32:0 "Realm Unifier £adm£"
+# Tooltips for the Government Buildings explaining you get access to Empowered Edicts.
+ building_town_hall_desc:0 "Enables the use of §YTier 2 State Edicts§! in a state that has this building in every province.\n§Y!§!Reaching or losing this requirement will turn off the current State Edict."
+ building_government_lvl_3_desc:0 "Enables the use of §YTier 3 State Edicts§! in a state that has this building in every province.\n§Y!§!Reaching or losing this requirement will turn off the current State Edict."
+ building_government_lvl_4_desc:0 "Enables the use of §YTier 4 State Edicts§! in a state that has this building in every province.\n§Y!§!Reaching or losing this requirement will turn off the current State Edict."
  


### PR DESCRIPTION
Looks like this:
![image](https://user-images.githubusercontent.com/49829764/81288613-40b63100-9065-11ea-97da-de4a1bfaf58a.png)
