### PR TITLE
Add missing buildings to scripted triggers

### DIFF
--- a/common/scripted_triggers/missions_expanded_buildings_scripted_triggers.txt
+++ b/common/scripted_triggers/missions_expanded_buildings_scripted_triggers.txt
@@ -640,27 +640,71 @@ province_has_at_least_num_of_buildings = {
 	# you can use this trigger with custom_trigger_tooltip if necessary, HAS_AT_LEAST_<0-10>_BUILDINGS are localized
 	calc_true_if = {
 		has_building = marketplace
+		has_building = trade_lvl_2
 		has_building = trade_depot
 		has_building = stock_exchange
 		has_building = courthouse
 		has_building = town_hall
+		has_building = government_lvl_3
+		has_building = government_lvl_4
 		has_building = university
 		has_building = dock
+		has_building = navymanpower_lvl_2
 		has_building = drydock
 		has_building = shipyard
+		has_building = navyforcelimit_lvl_2
 		has_building = grand_shipyard
 		has_building = workshop
+		has_building = production_lvl_2
+		has_building = production_lvl_3
 		has_building = counting_house
+		has_building = manpower_lvl_1
 		has_building = barracks
 		has_building = training_fields
+		has_building = forcelimit_lvl_1
 		has_building = regimental_camp
 		has_building = conscription_center
 		has_building = temple
+		has_building = taxation_lvl_2
 		has_building = cathedral
+		has_building = taxation_lvl_4
 		has_building = fort_15th
 		has_building = fort_16th
 		has_building = fort_17th
 		has_building = fort_18th
+		has_building = manufactory
+		has_building = wharf
+		has_building = weapons
+		has_building = textile
+		has_building = plantations
+		has_building = tradecompany
+		has_building = farm_estate
+		has_building = mills
+		has_building = furnace
+		has_building = infrastructure_lvl_1
+		has_building = infrastructure_lvl_2
+		has_building = infrastructure_lvl_3
+		has_building = infrastructure_lvl_4
+		has_building = terrain_land
+		has_building = terrain_woodland
+		has_building = terrain_desert
+		has_building = terrain_hills
+		has_building = terrain_art
+		has_building = terrain_jungle
+		has_building = terrain_swamp
+		has_building = terrain_coastal
+		has_building = navalbase_lvl_1
+		has_building = navalbase_lvl_2
+		has_building = fortress_keep
+		has_building = fortress_barracks
+		has_building = fortress_towers
+		has_building = fortress_artillery
+		has_building = fortress_wall
+		has_building = fortress_supply
+		has_building = el_escorial
+		has_building = blast_furnace
+		has_building = UKS_Palace
+		has_building = UKS_Palace_2
 		amount = $amount$
 	}
 }
@@ -670,6 +714,7 @@ province_has_at_least_num_of_buildings = {
 num_of_owned_trade_building_trigger = {
 	OR = {
 		marketplace = $amount$
+		trade_lvl_2 = $amount$
 		trade_depot = $amount$
 		stock_exchange = $amount$
 	}
@@ -679,6 +724,8 @@ num_of_owned_government_building_trigger = {
 	OR = {
 		courthouse = $amount$
 		town_hall = $amount$
+		government_lvl_3 = $amount$
+		government_lvl_4 = $amount$
 		university = $amount$
 	}
 }
@@ -686,23 +733,31 @@ num_of_owned_government_building_trigger = {
 num_of_owned_navy_building_trigger = {
 	OR = {
 		dock = $amount$
+		navymanpower_lvl_2 = $amount$
 		drydock = $amount$
 		shipyard = $amount$
+		navyforcelimit_lvl_2 = $amount$
 		grand_shipyard = $amount$
+		navalbase_lvl_1 = $amount$
+		navalbase_lvl_2 = $amount$
 	}
 }
 
 num_of_owned_production_building_trigger = {
 	OR = {
 		workshop = $amount$
+		production_lvl_2 = $amount$
+		production_lvl_3 = $amount$
 		counting_house = $amount$
 	}
 }
 
 num_of_owned_army_building_trigger = {
 	OR = {
+		manpower_lvl_1 = $amount$
 		barracks = $amount$
 		training_fields = $amount$
+		forcelimit_lvl_1 = $amount$ 
 		regimental_camp = $amount$
 		conscription_center = $amount$
 	}
@@ -711,7 +766,9 @@ num_of_owned_army_building_trigger = {
 num_of_owned_taxation_building_trigger = {
 	OR = {
 		temple = $amount$
+		taxation_lvl_2 = $amount$
 		cathedral = $amount$
+		taxation_lvl_4 = $amount$
 	}
 }
 


### PR DESCRIPTION
This adds the buildings added in IV to ME's `province_has_at_least_num_of_buildings` scripted trigger among other minor scripted triggers.

I added all the buildings I could find in the buildings folder, I think `manufactory` might be redundant.
There's also the beautiful mess of a trigger `province_has_building_of_group`, and it has a section at the very end where all the buildings from vanilla are listed. It might benefit from getting the same treatment as the at_least part. Don't really know what that section does though, and I don't want to break it.