### PR TITLE
Refactor all mission triggers to take account for new buildings

### DIFF
--- a/common/scripted_triggers/missions_expanded_buildings_scripted_triggers.txt
+++ b/common/scripted_triggers/missions_expanded_buildings_scripted_triggers.txt
@@ -79,7 +79,7 @@ can_forcelimit_line = {
 
 province_has_building_of_group = {
 	#	"group" that can be checked:
-	#		building groups (trade, government, navy, production, manpower, army, taxation, defense, all)
+	#		building groups (trade, government, navy, production, manpower, forcelimit, army, taxation, defense, all)
 	#		-- government does not use universities
 	#
 	#	use "all" to check if the province has any of the group's/sub group's buildings
@@ -114,8 +114,9 @@ province_has_building_of_group = {
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_barracks
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_training_fields
-	#		PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_regimental_camp
-	#		PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_conscription_center
+	#		PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL
+	#		PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_EOMAT_regimental_camp
+	#		PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_EOMAT_conscription_center
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_temple
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
@@ -144,8 +145,9 @@ province_has_building_of_group = {
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_barracks
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_training_fields
-	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_regimental_camp
-	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_conscription_center
+	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL
+	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_EOMAT_regimental_camp
+	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_EOMAT_conscription_center
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_temple
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
@@ -461,7 +463,7 @@ province_has_building_of_group = {
 					which = check_$group$_buildings
 					value = 1
 				}
-				check_variable = { check_army_buildings = 1 }
+				check_variable = { check_forcelimit_buildings = 1 }
 			}
 		}
 		[[all]
@@ -470,9 +472,6 @@ province_has_building_of_group = {
 					always = $all$
 				}
 				OR = {
-					has_building = manpower_lvl_1
-					has_building = barracks
-					has_building = training_fields
 					has_building = forcelimit_lvl_1
 					has_building = regimental_camp
 					has_building = conscription_center
@@ -497,6 +496,32 @@ province_has_building_of_group = {
 			}
 			else = {
 				has_building = conscription_center
+			}
+		]
+	}
+	else_if = {
+		limit = {
+			variable_arithmetic_trigger = {
+				export_to_variable = {
+					which = check_$group$_buildings
+					value = 1
+				}
+				check_variable = { check_army_buildings = 1 }
+			}
+		}
+		[[all]
+			if = {
+				limit = {
+					always = $all$
+				}
+				OR = {
+					has_building = manpower_lvl_1
+					has_building = barracks
+					has_building = training_fields
+					has_building = forcelimit_lvl_1
+					has_building = regimental_camp
+					has_building = conscription_center
+				}
 			}
 		]
 	}

--- a/common/scripted_triggers/missions_expanded_buildings_scripted_triggers.txt
+++ b/common/scripted_triggers/missions_expanded_buildings_scripted_triggers.txt
@@ -79,7 +79,7 @@ can_forcelimit_line = {
 
 province_has_building_of_group = {
 	#	"group" that can be checked:
-	#		building groups (trade, government, navy, production, army, taxation, defense, all)
+	#		building groups (trade, government, navy, production, manpower, army, taxation, defense, all)
 	#		-- government does not use universities
 	#
 	#	use "all" to check if the province has any of the group's/sub group's buildings
@@ -111,8 +111,9 @@ province_has_building_of_group = {
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_EOMAT_workshop
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_EOMAT_counting_house
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
-	#		PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_barracks
-	#		PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_training_fields
+	#		PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+	#		PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_barracks
+	#		PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_training_fields
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_regimental_camp
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_conscription_center
 	#		PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
@@ -140,8 +141,9 @@ province_has_building_of_group = {
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_EOMAT_workshop
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_EOMAT_counting_house
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
-	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_barracks
-	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_training_fields
+	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_barracks
+	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_training_fields
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_regimental_camp
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_conscription_center
 	#		NOT_PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
@@ -407,7 +409,7 @@ province_has_building_of_group = {
 					which = check_$group$_buildings
 					value = 1
 				}
-				check_variable = { check_army_buildings = 1 }
+				check_variable = { check_manpower_buildings = 1 }
 			}
 		}
 		[[all]
@@ -419,9 +421,6 @@ province_has_building_of_group = {
 					has_building = manpower_lvl_1
 					has_building = barracks
 					has_building = training_fields
-					has_building = forcelimit_lvl_1
-					has_building = regimental_camp
-					has_building = conscription_center
 				}
 			}
 		]
@@ -453,7 +452,35 @@ province_has_building_of_group = {
 				}
 				has_building = training_fields
 			}
-			else_if = {
+		]
+	}
+	else_if = {
+		limit = {
+			variable_arithmetic_trigger = {
+				export_to_variable = {
+					which = check_$group$_buildings
+					value = 1
+				}
+				check_variable = { check_army_buildings = 1 }
+			}
+		}
+		[[all]
+			if = {
+				limit = {
+					always = $all$
+				}
+				OR = {
+					has_building = manpower_lvl_1
+					has_building = barracks
+					has_building = training_fields
+					has_building = forcelimit_lvl_1
+					has_building = regimental_camp
+					has_building = conscription_center
+				}
+			}
+		]
+		[[equal_or_more_advanced_than]
+			if = {
 				limit = {
 					variable_arithmetic_trigger = {
 						export_to_variable = {

--- a/decisions/ME_Timurids_Decisions.txt
+++ b/decisions/ME_Timurids_Decisions.txt
@@ -23,8 +23,7 @@ country_decisions = {
 				AND = {
 					NOT = { has_dlc = "Mandate of Heaven" }
 					province_id = 454
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
+					NOT = { province_has_building_of_group = { group = production all = yes } }
 				}
 			}
 		}
@@ -46,10 +45,7 @@ country_decisions = {
 			}
 			else = {
 				454 = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}

--- a/events/FlavorSPA.txt
+++ b/events/FlavorSPA.txt
@@ -233,7 +233,7 @@ country_event = {
 		name = "flavor_spa.EVTOPTA3150"
 		define_advisor = {
 			type = inquisitor
-			name = "Tomï¿½s de Torquemada"
+			name = "Tomás de Torquemada"
 			location = 215 # Castilla La Vieja 
 			discount = yes
 			skill = 1
@@ -357,7 +357,7 @@ country_event = {
 		add_years_of_income = -0.25
 		set_global_flag = columbus_happened
 		define_explorer = {
-			name = "Cristï¿½bal Colï¿½n"
+			name = "Cristóbal Colón"
 			fire = 2
 			shock = 2
 			manuever = 6
@@ -598,7 +598,7 @@ country_event = {
 }
 
 
-# Casa de Contrataciï¿½n
+# Casa de Contratación
 country_event = {
 	id = flavor_spa.1003
 	title = "flavor_spa.EVTNAME1003"
@@ -1299,7 +1299,7 @@ country_event = {
 	}
 }
 
-# Josï¿½ Monino
+# José Monino
 country_event = {
 	id = flavor_spa.3094
 	title = "flavor_spa.EVTNAME3094"
@@ -1330,7 +1330,7 @@ country_event = {
 		}
 		define_advisor = {
 			type = statesman
-			name = "Josï¿½ Monino"
+			name = "José Monino"
 			culture = andalucian
 			discount = yes
 			skill = 3
@@ -1405,7 +1405,7 @@ country_event = {
 	}
 }
 
-# Tomï¿½s Luis de Victoria
+# Tomás Luis de Victoria
 country_event = {
 	id = flavor_spa.1101
 	title = "flavor_spa.EVTNAME1101"
@@ -1600,7 +1600,7 @@ country_event = {
 	
 	
 
-	option = {		# Allow Sepï¿½lveda's arguments to shape our policies
+	option = {		# Allow Sepúlveda's arguments to shape our policies
 		name = "flavor_spa.2.a"
 		ai_chance = {
 			factor = 15
@@ -1874,7 +1874,7 @@ country_event = {
 	}
 }
 
-# Sï¿½lo Madrid es corte
+# Sólo Madrid es corte
 country_event = {
 	id = flavor_spa.6
 	title = "flavor_spa.6.t"
@@ -2008,7 +2008,7 @@ country_event = {
 			}
 			spawn_rebels = {
 				type = nationalist_rebels
-				leader = "Abï¿½n Umayyad"
+				leader = "Abén Umayyad"
 				friend = GRA
 				size = 2
 				win = yes

--- a/events/FlavorSPA.txt
+++ b/events/FlavorSPA.txt
@@ -233,7 +233,7 @@ country_event = {
 		name = "flavor_spa.EVTOPTA3150"
 		define_advisor = {
 			type = inquisitor
-			name = "Tomás de Torquemada"
+			name = "Tomï¿½s de Torquemada"
 			location = 215 # Castilla La Vieja 
 			discount = yes
 			skill = 1
@@ -357,7 +357,7 @@ country_event = {
 		add_years_of_income = -0.25
 		set_global_flag = columbus_happened
 		define_explorer = {
-			name = "Cristóbal Colón"
+			name = "Cristï¿½bal Colï¿½n"
 			fire = 2
 			shock = 2
 			manuever = 6
@@ -598,7 +598,7 @@ country_event = {
 }
 
 
-# Casa de Contratación
+# Casa de Contrataciï¿½n
 country_event = {
 	id = flavor_spa.1003
 	title = "flavor_spa.EVTNAME1003"
@@ -1299,7 +1299,7 @@ country_event = {
 	}
 }
 
-# José Monino
+# Josï¿½ Monino
 country_event = {
 	id = flavor_spa.3094
 	title = "flavor_spa.EVTNAME3094"
@@ -1330,7 +1330,7 @@ country_event = {
 		}
 		define_advisor = {
 			type = statesman
-			name = "José Monino"
+			name = "Josï¿½ Monino"
 			culture = andalucian
 			discount = yes
 			skill = 3
@@ -1405,7 +1405,7 @@ country_event = {
 	}
 }
 
-# Tomás Luis de Victoria
+# Tomï¿½s Luis de Victoria
 country_event = {
 	id = flavor_spa.1101
 	title = "flavor_spa.EVTNAME1101"
@@ -1600,7 +1600,7 @@ country_event = {
 	
 	
 
-	option = {		# Allow Sepúlveda's arguments to shape our policies
+	option = {		# Allow Sepï¿½lveda's arguments to shape our policies
 		name = "flavor_spa.2.a"
 		ai_chance = {
 			factor = 15
@@ -1874,7 +1874,7 @@ country_event = {
 	}
 }
 
-# Sólo Madrid es corte
+# Sï¿½lo Madrid es corte
 country_event = {
 	id = flavor_spa.6
 	title = "flavor_spa.6.t"
@@ -2008,7 +2008,7 @@ country_event = {
 			}
 			spawn_rebels = {
 				type = nationalist_rebels
-				leader = "Abén Umayyad"
+				leader = "Abï¿½n Umayyad"
 				friend = GRA
 				size = 2
 				win = yes
@@ -2668,7 +2668,7 @@ country_event = {
 		any_owned_province = {
 			has_province_modifier = merino_wool
 			OR = {
-				has_building = counting_house
+				province_has_building_of_group = { group = production equal_or_more_advanced_than = counting_house }
 				has_building = textile
 			}
 		}

--- a/events/GE_reform_cycle.txt
+++ b/events/GE_reform_cycle.txt
@@ -3904,7 +3904,7 @@ province_event = {
 			has_reform = papacy_reform
 		}
 		any_owned_province = {
-			NOT = { has_building = temple }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 		}
 	}
 	immediate = {

--- a/events/InvestmentEvents.txt
+++ b/events/InvestmentEvents.txt
@@ -801,12 +801,7 @@ country_event = {
 					investor = ROOT
 				}
 			}
-			NOT = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
-				}
-			}
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 		}
 		NOT = {
 			any_owned_province = {

--- a/events/ME_Ayyubid_Events.txt
+++ b/events/ME_Ayyubid_Events.txt
@@ -395,12 +395,7 @@ country_event = {    #Mission Event - Northern Defenses
 					region = anatolia_region
 					region = caucasia_region
 				}
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
-				}
+				province_has_building_of_group = { group = defense all = yes }
 				NOT = { has_province_modifier = AYY_northern_defense }
 			}
 			add_province_modifier = {

--- a/events/ME_Rhenish_Events.txt
+++ b/events/ME_Rhenish_Events.txt
@@ -38,7 +38,7 @@ country_event = {
 		
 		trigger = {
 			capital_scope = {
-				NOT = { has_building = town_hall }
+				NOT = { province_has_building_of_group = { group = government equal_or_more_advanced_than = town_hall } }
 			}
 		}
 		

--- a/events/PriceChanges.txt
+++ b/events/PriceChanges.txt
@@ -108,7 +108,7 @@ country_event = {
 	}
 }
 
-#Johann Friedrich Bï¿½ttger
+#Johann Friedrich Böttger
 country_event = {
 	id = prices.3
 	title = prices.3.t

--- a/events/PriceChanges.txt
+++ b/events/PriceChanges.txt
@@ -108,7 +108,7 @@ country_event = {
 	}
 }
 
-#Johann Friedrich Böttger
+#Johann Friedrich Bï¿½ttger
 country_event = {
 	id = prices.3
 	title = prices.3.t
@@ -1739,8 +1739,7 @@ country_event = {
 			province_without_special_goods_produced_trigger = yes
 			is_state = yes
 			OR = { #Somewhere reasonable for windmills 
-				has_building = workshop
-				has_building = counting_house
+				province_has_building_of_group = { group = production all = yes }
 				base_production = 6
 				has_port = yes
 			}
@@ -1765,8 +1764,7 @@ country_event = {
 					province_without_special_goods_produced_trigger = yes
 					is_state = yes
 					OR = { #Somewhere reasonable for windmills 
-						has_building = workshop
-						has_building = counting_house
+						province_has_building_of_group = { group = production all = yes }
 						base_production = 6
 						has_port = yes
 					}
@@ -1786,8 +1784,7 @@ country_event = {
 					is_state = yes
 					num_free_building_slots = 1 #prefered but not required
 					OR = { #Somewhere reasonable for windmills 
-						has_building = workshop
-						has_building = counting_house
+						province_has_building_of_group = { group = production all = yes }
 						base_production = 6
 						has_port = yes
 					}
@@ -1807,8 +1804,7 @@ country_event = {
 					is_state = yes
 					num_free_building_slots = 1
 					OR = { #Somewhere reasonable for windmills 
-						has_building = workshop
-						has_building = counting_house
+						province_has_building_of_group = { group = production all = yes }
 						base_production = 6
 						has_port = yes
 					}
@@ -1829,8 +1825,7 @@ country_event = {
 					is_state = yes
 					num_free_building_slots = 1
 					OR = { #Somewhere reasonable for windmills 
-						has_building = workshop
-						has_building = counting_house
+						province_has_building_of_group = { group = production all = yes }
 						base_production = 6
 						has_port = yes
 					}
@@ -1851,8 +1846,7 @@ country_event = {
 					is_state = yes
 					num_free_building_slots = 1
 					OR = { #Somewhere reasonable for windmills 
-						has_building = workshop
-						has_building = counting_house
+						province_has_building_of_group = { group = production all = yes }
 						base_production = 6
 						has_port = yes
 					}
@@ -2526,10 +2520,7 @@ country_event = {
 			manufactories = 100
 			is_state = yes
 			is_capital = no
-			OR = {
-				has_building = workshop
-				has_building = counting_house
-			}
+			province_has_building_of_group = { group = production all = yes }
 			province_without_special_goods_produced_trigger = yes
 		}
 	}
@@ -2542,10 +2533,7 @@ country_event = {
 					manufactories = 100
 					is_state = yes
 					is_capital = no
-					OR = {
-						has_building = workshop
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 					province_without_special_goods_produced_trigger = yes
 				}
 				save_event_target_as = glass_province

--- a/events/RandomEvents.txt
+++ b/events/RandomEvents.txt
@@ -10207,7 +10207,7 @@ country_event = {
 				random_owned_province = {
 					limit = {
 						has_owner_religion = yes
-						has_building = temple
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 					save_event_target_as = origin_of_bishop
 				}

--- a/events/ReformEvents.txt
+++ b/events/ReformEvents.txt
@@ -5119,7 +5119,7 @@ country_event = {
 		hidden_effect = {
 			random_owned_province = {
 				limit = {
-					has_building = temple
+					province_has_building_of_group = { group = taxation all = yes }
 					is_territory = no
 					NOT = { nationalism = 1 }
 					NOT = { religion = ROOT }
@@ -5255,19 +5255,11 @@ country_event = {
 		any_owned_province = {
 			OR = {
 				AND = {
-					OR = {
-						has_building = temple
-						has_building = cathedral
-					}
+					province_has_building_of_group = { group = taxation all = yes }
 					NOT = { has_province_modifier = Church_Poorhouses }
 				}
 				AND = {
-					NOT = { 
-						OR = {
-							has_building = temple
-							has_building = cathedral
-						} 
-					}
+					NOT = { province_has_building_of_group = { group = taxation all = yes } }
 					has_province_modifier = Church_Poorhouses
 				}
 			}
@@ -5281,10 +5273,7 @@ country_event = {
 	immediate = {
 		every_owned_province = {
 			limit = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
-				}
+				province_has_building_of_group = { group = taxation all = yes }
 				NOT = {	has_province_modifier = Church_Poorhouses }
             }
 			add_province_modifier = {
@@ -5294,12 +5283,7 @@ country_event = {
 		}
 		every_owned_province = {
 			limit = {
-				NOT = { 
-					OR = {
-						has_building = temple
-						has_building = cathedral
-					} 
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				has_province_modifier = Church_Poorhouses
             }
 			remove_province_modifier = Church_Poorhouses

--- a/events/ReformEvents.txt
+++ b/events/ReformEvents.txt
@@ -7783,12 +7783,7 @@ country_event = {
 		any_owned_province = {
 			OR = {
 				AND = {
-					OR = {
-						has_building = workshop
-						has_building = production_lvl_2
-						has_building = production_lvl_3
-						has_building = counting_house 
-					}
+					province_has_building_of_group = { group = production all = yes }
 					NOT = { has_province_modifier = Promoted_Industry }
 				}
 			}
@@ -7802,12 +7797,7 @@ country_event = {
 	immediate = {
 		every_owned_province = {
 			limit = {
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house 
-				}
+				province_has_building_of_group = { group = production all = yes }
 				NOT = {	has_province_modifier = Promoted_Industry }
             }
 			add_province_modifier = {

--- a/events/SiberianColonization.txt
+++ b/events/SiberianColonization.txt
@@ -52,7 +52,7 @@ country_event = {
 					is_capital = no
 					is_in_capital_area = yes
 					is_state = yes
-					has_building = marketplace
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				save_event_target_as = russian_center_of_trade
 			}
@@ -245,7 +245,7 @@ country_event = {
 					is_capital = no
 					is_in_capital_area = yes
 					is_state = yes
-					has_building = marketplace
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				save_event_target_as = russian_center_of_trade
 			}

--- a/localisation/ME_United_Kingdoms_l_english.yml
+++ b/localisation/ME_United_Kingdoms_l_english.yml
@@ -217,7 +217,7 @@
  England_tooltip.17: "The Decision to form @UKS §Y[UKS.GetName]§! is unlocked."
  England_tooltip.18: "The §YGreat Palace§! is upgraded, giving twice as powerful modifiers."
  England_tooltip.19: "All Centers of Trade in the §YEnglish Channel§! are level 2 or higher"
- England_tooltip.20: "All Centers of Trade in the §YEnglish Channel§! have a §YMarketplace§!, §YTrade Depot§! or §YStock Exchange§!"
+ England_tooltip.20: "All Centers of Trade in the §YEnglish Channel§! have a §YMarketplace§!, §YGrand Marketplace§!, §YTrade Depot§! or §YStock Exchange§!"
  England_tooltip.21: "Every province in the §YEnglish Channel§! gets '§YMonopoly§!' until the end of the game, giving the following effects:\nTrade Value Modifier: §G+10.0%§!"
  England_tooltip.22: "All provinces in the §YEnglish Channel§! have a §YManufactory§!"
  England_tooltip.23: "§Y[Root.Country.GetName]§! has at least 5 claims in the Italian Region."

--- a/localisation/_ME_scripted_triggers_and_effects_l_english.yml
+++ b/localisation/_ME_scripted_triggers_and_effects_l_english.yml
@@ -45,12 +45,17 @@
  PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL: " One of the following must be true: \n         Have an §YArmoury§! \n         Have a §YBarracks§! \n         Have a §YTraining Fields§!"
  PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_barracks: " One of the following must be true: \n         Have a §YBarracks§! \n         Have a §YTraining Fields§!"
  PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_training_fields: " Have a §YTraining Fields§!"
- 
- PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_regimental_camp: " One of the following must be true: \n         Have a §YRegimental Camp§! \n         Have a §YManeuver Area§!"
- PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_conscription_center: " Have a §YManeuver Area§!"
+ PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL: " One of the following must be true: \n         Have a §YCompany Camp§! \n         Have a §YRegimental Camp§! \n         Have a §YManeuver Area§!"
+ PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_EOMAT_regimental_camp: " One of the following must be true: \n         Have a §YRegimental Camp§! \n         Have a §YManeuver Area§!"
+ PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_EOMAT_conscription_center: " Have a §YManeuver Area§!"
  NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL: "   Do NOT have an §YArmoury§! \n   Do NOT have a §YBarracks§! \n   Do NOT have a §YTraining Fields§! \n   Do NOT have a §YRegimental Camp§! \n   Do NOT have a §YManeuver Area§!"
+ NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL: "   Do NOT have an §YArmoury§! \n   Do NOT have a §YBarracks§! \n   Do NOT have a §YTraining Fields§!"
  NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_barracks: "   Do NOT have a §YBarracks§! \n   Do NOT have a §YTraining Fields§!"
  NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_training_fields: "   Do NOT have a §YTraining Fields§!"
+ NOT_PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL: "   Do NOT have a §YTraining Fields§! \n   Do NOT have a §YRegimental Camp§! \n   Do NOT have a §YManeuver Area§!"
+ NOT_PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_EOMAT_regimental_camp: "   Do NOT have a §YRegimental Camp§! \n   Do NOT have a §YManeuver Area§!"
+ NOT_PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_EOMAT_conscription_center: "   Do NOT have a §YManeuver Area§!"
+
  NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_regimental_camp: "   Do NOT have a §YRegimental Camp§! \n   Do NOT have a §YManeuver Area§!"
  NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_conscription_center: "   Do NOT have a §YManeuver Area§!"
  

--- a/localisation/_ME_scripted_triggers_and_effects_l_english.yml
+++ b/localisation/_ME_scripted_triggers_and_effects_l_english.yml
@@ -42,13 +42,15 @@
  
  ## Army Buildings:
  PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL: " One of the following must be true: \n         Have an §YArmoury§! \n         Have a §YBarracks§! \n         Have a §YTraining Fields§! \n         Have a §YCompany Camp§! \n         Have a §YRegimental Camp§! \n         Have a §YManeuver Area§!"
- PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_barracks: " One of the following must be true: \n         Have an §YArmoury§! \n         Have a §YBarracks§! \n         Have a §YTraining Fields§!"
- PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_training_fields: " Have a §YTraining Fields§!"
+ PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL: " One of the following must be true: \n         Have an §YArmoury§! \n         Have a §YBarracks§! \n         Have a §YTraining Fields§!"
+ PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_barracks: " One of the following must be true: \n         Have a §YBarracks§! \n         Have a §YTraining Fields§!"
+ PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_training_fields: " Have a §YTraining Fields§!"
+ 
  PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_regimental_camp: " One of the following must be true: \n         Have a §YRegimental Camp§! \n         Have a §YManeuver Area§!"
  PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_conscription_center: " Have a §YManeuver Area§!"
  NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL: "   Do NOT have an §YArmoury§! \n   Do NOT have a §YBarracks§! \n   Do NOT have a §YTraining Fields§! \n   Do NOT have a §YRegimental Camp§! \n   Do NOT have a §YManeuver Area§!"
- NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_barracks: "   Do NOT have a §YBarracks§! \n   Do NOT have a §YTraining Fields§!"
- NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_training_fields: "   Do NOT have a §YTraining Fields§!"
+ NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_barracks: "   Do NOT have a §YBarracks§! \n   Do NOT have a §YTraining Fields§!"
+ NOT_PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_EOMAT_training_fields: "   Do NOT have a §YTraining Fields§!"
  NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_regimental_camp: "   Do NOT have a §YRegimental Camp§! \n   Do NOT have a §YManeuver Area§!"
  NOT_PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_EOMAT_conscription_center: "   Do NOT have a §YManeuver Area§!"
  

--- a/localisation/replace/ME_replace_l_english.yml
+++ b/localisation/replace/ME_replace_l_english.yml
@@ -102,4 +102,5 @@
  MNG_consolidate_priviliges: "§GConsolidate Executive Privileges§!"
  MNG_send_eunuch_emissaries: "§TSend Eunuch Emissaries§!"
  MNG_placate_the_heavens: "§gPlacate the Heavens§!" # rare GREY color, this has a weird effect
- 
+ mission_market_place_with_asian_traders.t: "Have a §YMarketplace§! (or higher tier trade building) in every province in §YEnglish home area§!, that has a §YCenter of Trade§!"
+ tatar_silk_road_tooltip_3: "Have at least $Y8$! total §YMarketplaces§! (or higher tier trade buildings) in provinces in §YPersia§!, §YCentral Asia§! and §YKhorasan§! regions."

--- a/missions/01_Generic_missions.txt
+++ b/missions/01_Generic_missions.txt
@@ -290,8 +290,15 @@ administrative_missions = {
 		icon = mission_early_game_buildings
 		required_missions = { high_income_mission }
 		trigger = {
-			temple = 5
-			workshop = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
+				}
+				amount = 5
+			}
 		}
 		effect = {
 			add_adm_power = 50

--- a/missions/Bohemian_Missions.txt
+++ b/missions/Bohemian_Missions.txt
@@ -173,7 +173,10 @@ boh_development_group = {
 		
 		trigger = {
 			capital_scope = {
-				has_building = cathedral
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
+						province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral }
+					}
 				has_building = university
 			}
 		}

--- a/missions/GC_Aragonese_Missions.txt
+++ b/missions/GC_Aragonese_Missions.txt
@@ -36,7 +36,7 @@ gc_aragon_1 = {
 						province_id = 220
 					}
 					OR = {
-						NOT = { has_building = marketplace }
+						NOT = { province_has_building_of_group = { group = trade all = yes } }
 						NOT = { owned_by = ROOT }
 					}
 				}
@@ -50,11 +50,17 @@ gc_aragon_1 = {
 				}
 			}
 			213 = {
-				has_building = marketplace
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+				}
 				owned_by = ROOT
 			}
 			220 = {
-				has_building = marketplace
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+				}
 				owned_by = ROOT
 			}
 		}

--- a/missions/GC_Granadan_Missions.txt
+++ b/missions/GC_Granadan_Missions.txt
@@ -57,7 +57,10 @@ granada_development_missions = {
 			223 = {
 				owned_by = ROOT
 				development = 20
-				has_building = temple
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
+				}
 			}
 		}
 		
@@ -114,7 +117,10 @@ andalusia_slot_1_missions = {
 				owned_by = ROOT
 				OR = {
 					development = 15
-					has_building = temple
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
 			}
 			lower_andalucia_area = {

--- a/missions/GC_Portuguese_Missions.txt
+++ b/missions/GC_Portuguese_Missions.txt
@@ -204,12 +204,7 @@ gc_por_1_b = {
 		provinces_to_highlight = {
 			trade_goods = wine
 			NOT = { owned_by = ROOT }
-			NOT = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
-				}
-			}
+			NOT = { province_has_building_of_group = { group = production all = yes } }
 			has_discovered = ROOT
 		}
 		
@@ -220,9 +215,9 @@ gc_por_1_b = {
 					num_of_provinces_owned_or_owned_by_non_sovereign_subjects_with = {
 						value = 10
 						trade_goods = wine
-						OR = {
-							has_building = workshop
-							has_building = counting_house
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+							province_has_building_of_group = { group = production all = yes }
 						}
 					}
 				}

--- a/missions/GC_Portuguese_Missions.txt
+++ b/missions/GC_Portuguese_Missions.txt
@@ -102,10 +102,9 @@ gc_por_1 = {
 			}
 			else = {
 				763 = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 			}
@@ -257,10 +256,9 @@ gc_por_1_b = {
 			}
 			num_of_provinces_owned_or_owned_by_non_sovereign_subjects_with = {
 				value = 10
-				OR = {
-					has_building = trade_depot
-					has_building = stock_exchange
-				
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_trade_depot
+						province_has_building_of_group = { group = trade equal_or_more_advanced_than = trade_depot }
 				}
 			}
 		}

--- a/missions/GC_Spanish_Missions.txt
+++ b/missions/GC_Spanish_Missions.txt
@@ -170,11 +170,9 @@ gc_spain_1_b = {
 		trigger = {
 			484 = {
 				country_or_non_sovereign_subject_holds = ROOT
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			custom_trigger_tooltip = {

--- a/missions/GC_Spanish_Missions.txt
+++ b/missions/GC_Spanish_Missions.txt
@@ -1089,9 +1089,9 @@ gc_spain_3_b = {
 			}
 			else = {
 				809 = {
-					OR = {
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_trade_depot
+						province_has_building_of_group = { group = trade equal_or_more_advanced_than = trade_depot }
 					}
 				}
 			}

--- a/missions/GC_Spanish_Missions.txt
+++ b/missions/GC_Spanish_Missions.txt
@@ -415,11 +415,9 @@ gc_spain_2_b = {
 		trigger = {
 			490 = {
 				country_or_non_sovereign_subject_holds = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			custom_trigger_tooltip = {

--- a/missions/Japanese_Missions.txt
+++ b/missions/Japanese_Missions.txt
@@ -850,14 +850,14 @@ japanse_missions_domestic = {
 		required_missions = { unite_japan_mission }
 		
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 15
-				OR = {
-					has_building = temple
-					has_building = cathedral
-					has_building = workshop
-					has_building = counting_house
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
+				amount = 15
 			}
 		}
 		effect = {

--- a/missions/Korean_Missions.txt
+++ b/missions/Korean_Missions.txt
@@ -758,10 +758,9 @@ kor_fortify_missions = {
 					province_id = 2743
 					province_id = 2742
 				}
-				OR = {
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+					province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 				}
 			}
 		}
@@ -776,10 +775,9 @@ kor_fortify_missions = {
 								province_id = 2743
 								province_id = 2742
 							}
-							OR = {
-								has_building = fort_16th
-								has_building = fort_17th
-								has_building = fort_18th
+							custom_trigger_tooltip = {
+								tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+								province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 							}
 						}
 					}
@@ -795,10 +793,9 @@ kor_fortify_missions = {
 							province_id = 2743
 							province_id = 2742
 						}
-						OR = {
-							has_building = fort_16th
-							has_building = fort_17th
-							has_building = fort_18th
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+							province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 						}
 					}
 					add_province_modifier = {
@@ -818,7 +815,10 @@ kor_fortify_missions = {
 		trigger = {
 			num_of_owned_provinces_with = {
 				value = 5
-				has_building = fort_18th
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_18th
+						province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_18th }
+					}
 			}
 		}
 		effect = {

--- a/missions/Korean_Missions.txt
+++ b/missions/Korean_Missions.txt
@@ -1565,13 +1565,14 @@ korea_trade_group = {
 			NOT = { owned_by = root }
 		}
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 6
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
 				}
+				amount = 6
 			}
 			owns = 2745
 		}

--- a/missions/Korean_Missions.txt
+++ b/missions/Korean_Missions.txt
@@ -407,12 +407,14 @@ kor_military_missions_2 = {
 		trigger = {
 			num_of_artillery = 3
 			artillery_fraction = 0.3
-			num_of_owned_provinces_with = {
-				value = 2
-				OR = {
-					has_building = regimental_camp
-					has_building = conscription_center
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL
+						province_has_building_of_group = { group = forcelimit all = yes }
+					}
 				}
+				amount = 2
 			}
 		}
 		effect = {

--- a/missions/ME_000_Generic_Japan_Missions.txt
+++ b/missions/ME_000_Generic_Japan_Missions.txt
@@ -183,11 +183,9 @@ generic_japan_me_2 = {
 					has_building = fort_17th
 					has_building = fort_18th
 				}
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_000_Generic_Japan_Missions.txt
+++ b/missions/ME_000_Generic_Japan_Missions.txt
@@ -185,12 +185,13 @@ generic_japan_me_2 = {
 				}
 				OR = {
 					has_building = temple
+					has_building = taxation_lvl_2
 					has_building = cathedral
+					has_building = taxation_lvl_4
 				}
-				OR = {
-					has_building = marketplace
-					has_building = stock_exchange
-					has_building = trade_depot
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_000_Generic_Japan_Missions.txt
+++ b/missions/ME_000_Generic_Japan_Missions.txt
@@ -177,19 +177,17 @@ generic_japan_me_2 = {
 		trigger = {
 			num_of_owned_provinces_with = {
 				value = 2
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
-						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
-						province_has_building_of_group = { group = trade all = yes }
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_000_Westphalian_Minors_Missions.txt
+++ b/missions/ME_000_Westphalian_Minors_Missions.txt
@@ -390,7 +390,15 @@ westphalian_minor_missions_missions_5 = {
 		required_missions = { wes_min_country_wide_projects }
 		position = 2
 		trigger = {
-			barracks = 3
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
+					}
+				}
+				amount = 3
+			}
 		}
 		effect = {
 			add_country_modifier = {

--- a/missions/ME_000_Westphalian_Minors_Missions.txt
+++ b/missions/ME_000_Westphalian_Minors_Missions.txt
@@ -229,8 +229,10 @@ westphalian_minor_missions_missions_3 = {
 		position = 2
 		trigger = {
 			capital_scope = {
-				has_building = temple
-				has_building = workshop
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
+				}
 			}
 		}
 		effect = {

--- a/missions/ME_Aachen_Missions.txt
+++ b/missions/ME_Aachen_Missions.txt
@@ -483,7 +483,10 @@ aachen_form_francia_mission = {
 			OR = {
 				any_owned_province = {
 					trade_goods  = cloth
-					has_building = workshop
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
+					}
 				}
 				1876 = {
 					trade_share = {

--- a/missions/ME_Afganistan_Missions.txt
+++ b/missions/ME_Afganistan_Missions.txt
@@ -338,11 +338,9 @@ Afghanistan_missions_slot_4 = {
 		trigger = {
 			2228 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Ajam_Missions.txt
+++ b/missions/ME_Ajam_Missions.txt
@@ -113,12 +113,7 @@ QOM_missions_2 = {
 			province_id = 429
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 			ROOT = {
 				NOT = { num_of_allies = 2 }
@@ -130,11 +125,9 @@ QOM_missions_2 = {
 				AND = {
 					owns = 429
 					429 = {
-						OR = {
-							has_building = fort_15th
-							has_building = fort_16th
-							has_building = fort_17th
-							has_building = fort_18th
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+							province_has_building_of_group = { group = defense all = yes }
 						}
 					}
 				}
@@ -145,11 +138,9 @@ QOM_missions_2 = {
 				limit = {
 					owns = 429
 					429 = {
-						OR = {
-							has_building = fort_15th
-							has_building = fort_16th
-							has_building = fort_17th
-							has_building = fort_18th
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+							province_has_building_of_group = { group = defense all = yes }
 						}
 					}
 				}

--- a/missions/ME_Ajam_Missions.txt
+++ b/missions/ME_Ajam_Missions.txt
@@ -624,20 +624,15 @@ QOM_missions_5 = {
 			province_id = 2213
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = {	province_has_building_of_group = { group = trade all = yes } } 
 			}
 		}
 		trigger = {
 			owns = 2213
 			2213 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			4341 = {

--- a/missions/ME_Ajam_Missions.txt
+++ b/missions/ME_Ajam_Missions.txt
@@ -18,10 +18,7 @@ QOM_missions_1 = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_capital_of = ROOT }
 				NOT = { development = 12 }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
@@ -30,9 +27,9 @@ QOM_missions_1 = {
 			capital = 2213
 			2213 = {
 				development = 12
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Albania_Missions.txt
+++ b/missions/ME_Albania_Missions.txt
@@ -15,22 +15,15 @@ Albania_missions_1 = {
 			province_id = 4174
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			4174 = {
 				country_or_non_sovereign_subject_holds = ROOT
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			num_of_light_ship = 4

--- a/missions/ME_Annam_Missions.txt
+++ b/missions/ME_Annam_Missions.txt
@@ -231,11 +231,9 @@ annam_missions_slot_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = dock
-						has_building = drydock
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+						province_has_building_of_group = { group = navy all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Annam_Missions.txt
+++ b/missions/ME_Annam_Missions.txt
@@ -173,10 +173,9 @@ annam_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Annam_Missions.txt
+++ b/missions/ME_Annam_Missions.txt
@@ -258,8 +258,10 @@ annam_missions_slot_4 = {
 			calc_true_if = {
 				all_owned_province = {
 					OR = {
-						has_building = courthouse
-						has_building = town_hall
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+							province_has_building_of_group = { group = government all = yes }
+						}
 						has_building = university
 					}
 				}

--- a/missions/ME_Annam_Missions.txt
+++ b/missions/ME_Annam_Missions.txt
@@ -197,9 +197,9 @@ annam_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Annam_Missions.txt
+++ b/missions/ME_Annam_Missions.txt
@@ -282,11 +282,9 @@ annam_missions_slot_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Arabia_Missions.txt
+++ b/missions/ME_Arabia_Missions.txt
@@ -625,12 +625,7 @@ ARB_missions_3 = {
 					province_id = 410
 					OR = {
 						NOT = { owned_by = ROOT }
-						AND = {
-							NOT = { has_building = workshop }
-							NOT = { has_building = production_lvl_2 }
-							NOT = { has_building = production_lvl_3 }
-							NOT = { has_building = counting_house }
-						}
+						NOT = { province_has_building_of_group = { group = production all = yes } }
 						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 					}
 				}
@@ -653,11 +648,9 @@ ARB_missions_3 = {
 			else = {
 				410 = {
 					owned_by = ROOT
-					OR = {
-						has_building = workshop
-						has_building = production_lvl_2
-						has_building = production_lvl_3
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 					custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL

--- a/missions/ME_Arabia_Missions.txt
+++ b/missions/ME_Arabia_Missions.txt
@@ -631,12 +631,7 @@ ARB_missions_3 = {
 							NOT = { has_building = production_lvl_3 }
 							NOT = { has_building = counting_house }
 						}
-						AND = {
-							NOT = { has_building = temple }
-							NOT = { has_building = taxation_lvl_2 }
-							NOT = { has_building = cathedral }
-							NOT = { has_building = taxation_lvl_4 }
-						}
+						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 					}
 				}
 			}
@@ -664,11 +659,9 @@ ARB_missions_3 = {
 						has_building = production_lvl_3
 						has_building = counting_house
 					}
-					OR = {
-						has_building = temple
-						has_building = taxation_lvl_2
-						has_building = cathedral
-						has_building = taxation_lvl_4
+					custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 					}
 				}
 			}

--- a/missions/ME_Aragon_Missions.txt
+++ b/missions/ME_Aragon_Missions.txt
@@ -1947,12 +1947,7 @@ ARA_missions_5 = {
 		effect = {
 			every_owned_province = {
 				limit = {
-					OR = {
-						has_building = workshop
-						has_building = production_lvl_2
-						has_building = production_lvl_3
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 				}
 				add_province_modifier = {
 					name = ara_production

--- a/missions/ME_Aragon_Missions.txt
+++ b/missions/ME_Aragon_Missions.txt
@@ -801,10 +801,9 @@ ARA_missions_2 = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 						province_has_building_of_group = { group = trade all = yes }
 					}
-					OR = {
-						has_building = shipyard
-						has_building = navyforcelimit_lvl_2
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 					}
 					custom_trigger_tooltip = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock

--- a/missions/ME_Aragon_Missions.txt
+++ b/missions/ME_Aragon_Missions.txt
@@ -797,11 +797,9 @@ ARA_missions_2 = {
 				num_of_owned_provinces_with = {
 					value = 5
 					development = 20
-					OR = {
-						has_building = marketplace
-						has_building = trade_lvl_2
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 					OR = {
 						has_building = shipyard
@@ -1663,10 +1661,14 @@ ARA_missions_4 = {
 		required_missions = { }
 		position = 16
 		trigger = {
-			OR = {
-				marketplace = 5
-				trade_depot = 5
-				stock_exchange = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 5
 			}
 		}
 		effect = {
@@ -1683,7 +1685,15 @@ ARA_missions_4 = {
 		required_missions = { ara_build_marketplaces }
 		position = 17
 		trigger = {
-			stock_exchange = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_stock_exchange
+						province_has_building_of_group = { group = trade equal_or_more_advanced_than = stock_exchange }
+					}
+				}
+				amount = 5
+			}
 		}
 		effect = {
 			add_country_modifier = {

--- a/missions/ME_Aragon_Missions.txt
+++ b/missions/ME_Aragon_Missions.txt
@@ -806,10 +806,9 @@ ARA_missions_2 = {
 						has_building = navyforcelimit_lvl_2
 						has_building = grand_shipyard
 					}
-					OR = {
-						has_building = dock
-						has_building = navymanpower_lvl_2
-						has_building = drydock
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 					}
 				}
 			}

--- a/missions/ME_Ardabil_Missions.txt
+++ b/missions/ME_Ardabil_Missions.txt
@@ -424,12 +424,14 @@ ARL_missions_2 = {
 		required_missions = { ARL_Shia_state_religion }
 		position = 10
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 15
-				OR = {
-					has_building = temple
-					has_building = cathedral
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
+				amount = 15
 			}
 		}
 		effect = {

--- a/missions/ME_Armenia_Missions.txt
+++ b/missions/ME_Armenia_Missions.txt
@@ -217,11 +217,14 @@ armenia_missions_slot_3_1 = {
 			armenia_redevelop_yerevan
 		}
 		trigger = {
-			OR = {
-				fort_15th = 7
-				fort_16th = 7
-				fort_17th = 7
-				fort_18th = 7
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+						province_has_building_of_group = { group = defense all = yes }
+					}
+				}
+				amount = 7
 			}
 		}
 		effect = {

--- a/missions/ME_Armenia_Missions.txt
+++ b/missions/ME_Armenia_Missions.txt
@@ -190,11 +190,9 @@ armenia_missions_slot_3_1 = {
 		trigger = {
 			419 = {
 				development = 20
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Ashikaga_Missions.txt
+++ b/missions/ME_Ashikaga_Missions.txt
@@ -63,12 +63,7 @@ ASK_missions_1 = {
 					NOT = { has_building = cathedral }
 					NOT = { has_building = taxation_lvl_4 }
 				}
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
@@ -79,11 +74,9 @@ ASK_missions_1 = {
 					has_building = cathedral
 					has_building = taxation_lvl_4
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2 
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Ashikaga_Missions.txt
+++ b/missions/ME_Ashikaga_Missions.txt
@@ -173,10 +173,7 @@ ASK_missions_2 = {
 		required_missions = { ASK_development_plan }
 		provinces_to_highlight = {
 			is_capital_of = ROOT
-			NOT = { has_building = fort_15th }
-			NOT = { has_building = fort_16th }
-			NOT = { has_building = fort_17th }
-			NOT = { has_building = fort_18th }
+			NOT = { province_has_building_of_group = { group = defense all = yes } }
 		}
 		trigger = {
 			capital_scope = {

--- a/missions/ME_Ashikaga_Missions.txt
+++ b/missions/ME_Ashikaga_Missions.txt
@@ -57,22 +57,15 @@ ASK_missions_1 = {
 		provinces_to_highlight = {
 			is_capital_of = ROOT
 			OR = {
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			capital_scope = {
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_Athens_Missions.txt
+++ b/missions/ME_Athens_Missions.txt
@@ -251,28 +251,22 @@ ath_missions_2 = {
 			}
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = manpower_lvl_1 }
-					NOT = { has_building = barracks }
-					NOT = { has_building = training_fields }
-				}
+				NOT = { province_has_building_of_group = { group = manpower all = yes } }
 			}
 		}
 		trigger = {
 			1773 = {
 				owned_by = ROOT
-				OR = {
-					has_building = manpower_lvl_1
-					has_building = barracks
-					has_building = training_fields
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+					province_has_building_of_group = { group = manpower all = yes }
 				}
 			}
 			145 = {
 				owned_by = ROOT
-				OR = {
-					has_building = manpower_lvl_1
-					has_building = barracks
-					has_building = training_fields
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+					province_has_building_of_group = { group = manpower all = yes }
 				}
 			}
 		}
@@ -291,21 +285,16 @@ ath_missions_2 = {
 			province_id = 147
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = manpower_lvl_1 }
-					NOT = { has_building = barracks }
-					NOT = { has_building = training_fields }
-				}
+				NOT = { province_has_building_of_group = { group = manpower all = yes } }
 				NOT = { base_manpower = 5 }
 			}
 		}
 		trigger = {
 			147 = {
 				owned_by = ROOT
-				OR = {
-					has_building = manpower_lvl_1
-					has_building = barracks
-					has_building = training_fields
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+					province_has_building_of_group = { group = manpower all = yes }
 				}
 				base_manpower = 5
 			}

--- a/missions/ME_Athens_Missions.txt
+++ b/missions/ME_Athens_Missions.txt
@@ -610,12 +610,7 @@ ath_missions_4 = {
 			province_id = 146
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				NOT = { development = 15 }
 				NOT = { base_production = 7 }
 			}
@@ -623,11 +618,9 @@ ath_missions_4 = {
 		trigger = {
 			146 = {
 				owned_by = ROOT
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2 
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				development = 15
 				base_production = 7

--- a/missions/ME_Athens_Missions.txt
+++ b/missions/ME_Athens_Missions.txt
@@ -76,10 +76,11 @@ ath_missions_1 = {
 			province_id = 144
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
+				NOT = { 
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+						province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
+					}
 				}
 				NOT = { base_manpower = 5 }
 			}
@@ -87,10 +88,9 @@ ath_missions_1 = {
 		trigger = {
 			144 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+					province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 				}
 				base_manpower = 5
 			}

--- a/missions/ME_Avaria_Missions.txt
+++ b/missions/ME_Avaria_Missions.txt
@@ -15,22 +15,15 @@ AVR_missions_1 = {
 			province_id = 2198
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			2198 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}
@@ -54,10 +47,7 @@ AVR_missions_1 = {
 				NOT = { owned_by = ROOT }
 				AND = {
 					NOT = { base_manpower = 7 }
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
+					NOT = { province_has_building_of_group = { group = defense all = yes } }
 				}
 			}
 		}
@@ -66,10 +56,10 @@ AVR_missions_1 = {
 				owned_by = ROOT
 				OR = {
 					base_manpower = 7
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+						province_has_building_of_group = { group = defense all = yes }
+					}
 				}
 			}
 		}

--- a/missions/ME_Avignon_Missions.txt
+++ b/missions/ME_Avignon_Missions.txt
@@ -458,10 +458,7 @@ avignon_mission_group_5 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
@@ -471,9 +468,9 @@ avignon_mission_group_5 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}

--- a/missions/ME_Avignon_Missions.txt
+++ b/missions/ME_Avignon_Missions.txt
@@ -457,10 +457,7 @@ avignon_mission_group_5 = {
 			province_id = 202
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				AND = {
 					NOT = { has_building = workshop }
 					NOT = { has_building = counting_house }
@@ -470,9 +467,9 @@ avignon_mission_group_5 = {
 		trigger = {
 			owns = 202
 			202 = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				OR = {
 					has_building = workshop

--- a/missions/ME_Azerbaijani_Missions.txt
+++ b/missions/ME_Azerbaijani_Missions.txt
@@ -684,19 +684,14 @@ AZE_Missions_1 = {
 		provinces_to_highlight = {
 			owned_by = ROOT
 			has_terrain = mountain
-			NOT = { has_building = fort_15th }
-			NOT = { has_building = fort_16th }
-			NOT = { has_building = fort_17th }
-			NOT = { has_building = fort_18th }
+			NOT = { province_has_building_of_group = { group = defense all = yes } }
 		}
 		trigger = {
 			num_of_owned_provinces_with = {
 				has_terrain = mountain
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				value = 3
 			}

--- a/missions/ME_Azerbaijani_Missions.txt
+++ b/missions/ME_Azerbaijani_Missions.txt
@@ -401,13 +401,16 @@ Azerbaijani_Generic_Missions_SRV = {
 		position = 3
 		provinces_to_highlight = {
 			province_id = 421
-			NOT = { has_building = temple }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			NOT = { development = 15 }
 			NOT = { owned_by = ROOT }
 		}
 		trigger = {
 			421 = {
-				has_building = temple
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
+				}
 				development = 15
 				owned_by = ROOT
 			}
@@ -463,12 +466,15 @@ Azerbaijani_Generic_Missions_TBR = {
 		position = 3
 		provinces_to_highlight = {
 			province_id = 416
-			NOT = { has_building = temple }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			NOT = { owned_by = ROOT }
 		}
 		trigger = {
 			416 = {
-				has_building = temple
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
+				}
 				owned_by = ROOT
 			}
 		}

--- a/missions/ME_Banjar_Missions.txt
+++ b/missions/ME_Banjar_Missions.txt
@@ -214,10 +214,9 @@ BNJ_missions_slot_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Banjar_Missions.txt
+++ b/missions/ME_Banjar_Missions.txt
@@ -272,11 +272,9 @@ BNJ_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = dock
-						has_building = drydock
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+						province_has_building_of_group = { group = navy all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Banjar_Missions.txt
+++ b/missions/ME_Banjar_Missions.txt
@@ -298,10 +298,9 @@ BNJ_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = courthouse
-						has_building = town_hall
-						has_building = university
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+						province_has_building_of_group = { group = government all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Banjar_Missions.txt
+++ b/missions/ME_Banjar_Missions.txt
@@ -323,11 +323,9 @@ BNJ_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Banjar_Missions.txt
+++ b/missions/ME_Banjar_Missions.txt
@@ -238,9 +238,9 @@ BNJ_missions_slot_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Bavaria_Missions.txt
+++ b/missions/ME_Bavaria_Missions.txt
@@ -892,11 +892,9 @@ bavaria_missions_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Bavaria_Missions.txt
+++ b/missions/ME_Bavaria_Missions.txt
@@ -1066,23 +1066,16 @@ bavaria_missions_5 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 				NOT = { base_manpower = 5 }
 			}
 		}
 		trigger = {
 			owns_core_province = 65
 			65 = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				base_manpower = 5
 			}

--- a/missions/ME_Beylik_Aydin_Missions.txt
+++ b/missions/ME_Beylik_Aydin_Missions.txt
@@ -144,17 +144,14 @@ AYD_missions_4 = {
 		required_missions = { beylik_force_limit_mission }
 		provinces_to_highlight = {
 			province_id = 318
-			NOT = { has_building = temple }
-			NOT = { has_building = taxation_lvl_2 }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 		}
 		position = 2
 		trigger = {
 			318 = {
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				base_tax = 10
 			}

--- a/missions/ME_Beylik_Candar_Missions.txt
+++ b/missions/ME_Beylik_Candar_Missions.txt
@@ -102,7 +102,7 @@ CND_missions_5 = {
 		provinces_to_highlight = {
 			owned_by = ROOT
 			is_capital = yes
-			NOT = { has_building = temple }
+			NOT = { has_building = university }
 		}
 		trigger = {
 			if = {
@@ -129,15 +129,17 @@ CND_missions_5 = {
 		position = 2
 		provinces_to_highlight = {
 			owned_by = ROOT
-			NOT = { has_building = temple }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 		}
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = temple
-					has_building = cathedral
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Beylik_Candar_Missions.txt
+++ b/missions/ME_Beylik_Candar_Missions.txt
@@ -68,10 +68,9 @@ CND_missions_4 = {
 			328 = { #sinop
 				owned_by = ROOT
 				development = 20
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Beylik_Dulkadir_Missions.txt
+++ b/missions/ME_Beylik_Dulkadir_Missions.txt
@@ -62,9 +62,9 @@ DUL_missions_4 = {
 			}
 			stability = 3
 			capital_scope = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Beylik_Dulkadir_Missions.txt
+++ b/missions/ME_Beylik_Dulkadir_Missions.txt
@@ -22,12 +22,20 @@ DUL_missions_1 = {
 		position = 2
 		provinces_to_highlight = {
 			owned_by = ROOT
-			NOT = { has_building = barracks }
+			NOT = { province_has_building_of_group = { group = manpower all = yes } }
 		}
 		trigger = {
 			manpower_percentage = 1
 			manpower = 40
-			barracks = 3
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
+					}
+				}
+				amount = 3
+			}
 		}
 		effect = {
 			country_event = {

--- a/missions/ME_Beylik_Eretna_Missions .txt
+++ b/missions/ME_Beylik_Eretna_Missions .txt
@@ -74,9 +74,9 @@ ERE_missions_4 = {
 			rum_area = {
 				type = all
 				development = 10
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Beylik_Karaman_Missions.txt
+++ b/missions/ME_Beylik_Karaman_Missions.txt
@@ -150,15 +150,17 @@ KAR_missions_5 = {
 		position = 2
 		provinces_to_highlight = {
 			owned_by = ROOT
-			NOT = { has_building = temple }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 		}
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = temple
-					has_building = cathedral
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Beylik_Mentese_Missions.txt
+++ b/missions/ME_Beylik_Mentese_Missions.txt
@@ -79,13 +79,13 @@ MEN_missions_4 = {
 		position = 2
 		provinces_to_highlight = {
 			province_id = 319 #metesha
-			NOT = { has_building = temple }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 		}
 		trigger = {
 			319 = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				base_tax = 10
 			}

--- a/missions/ME_Beylik_Saruhan_Missions.txt
+++ b/missions/ME_Beylik_Saruhan_Missions.txt
@@ -152,15 +152,13 @@ SRU_missions_4 = {
 		position = 2
 		provinces_to_highlight = {
 			province_id = 2297 #manisa
-			NOT = { has_building = temple }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 		}
 		trigger = {
 			2297 = {
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				base_tax = 10
 			}

--- a/missions/ME_Beylik_zGenerics_Missions.txt
+++ b/missions/ME_Beylik_zGenerics_Missions.txt
@@ -42,7 +42,15 @@ beylik_missions_2 = {
 		position = 3
 		trigger = {
 			army_tradition = 50
-			barracks = 2
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
+					}
+				}
+				amount = 2
+			}
 			government_rank = 2
 		}
 		effect = {

--- a/missions/ME_Bohemia_Missions.txt
+++ b/missions/ME_Bohemia_Missions.txt
@@ -120,12 +120,7 @@ bohemia_missions_1 = {
 					NOT = { has_building = cathedral }
 					NOT = { has_building = taxation_lvl_4 }
 				}
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
@@ -138,11 +133,9 @@ bohemia_missions_1 = {
 					has_building = cathedral
 					 has_building = taxation_lvl_4
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Bohemia_Missions.txt
+++ b/missions/ME_Bohemia_Missions.txt
@@ -189,12 +189,7 @@ bohemia_missions_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 15 }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
@@ -202,11 +197,9 @@ bohemia_missions_1 = {
 			owns = 2967
 			2967 = {
 				development = 15
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Bohemia_Missions.txt
+++ b/missions/ME_Bohemia_Missions.txt
@@ -114,12 +114,7 @@ bohemia_missions_1 = {
 			province_id = 266
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
@@ -127,11 +122,9 @@ bohemia_missions_1 = {
 			years_of_income = 1
 			owns = 266
 			266 = {
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					 has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_Brunei_Missions.txt
+++ b/missions/ME_Brunei_Missions.txt
@@ -726,10 +726,14 @@ BEI_missions_4 = {
 		position = 2
 		required_missions = { Brunei_fleet }
 		trigger = {
-			OR = {
-				marketplace = 5
-				trade_depot = 5
-				stock_exchange = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Byzantium_Missions.txt
+++ b/missions/ME_Byzantium_Missions.txt
@@ -740,12 +740,7 @@ BYZ_missions_3 = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
 				has_owner_religion = no
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
@@ -754,31 +749,25 @@ BYZ_missions_3 = {
 			owns_core_province = 358
 			358 = {
 				has_owner_religion = yes
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			owns_core_province = 2313
 			2313 = {
 				has_owner_religion = yes
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			owns_core_province = 379
 			379 = {
 				has_owner_religion = yes
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -866,15 +855,12 @@ BYZ_missions_3 = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 40 }
 				NOT = { province_has_center_of_trade_of_level = 2 }
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				AND = {
 					NOT = { has_building = workshop }
 					NOT = { has_building = production_lvl_2 }
 					NOT = { has_building = production_lvl_3 }
 					NOT = { has_building = counting_house }
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
 				}
 			}
 		}
@@ -890,10 +876,10 @@ BYZ_missions_3 = {
 					has_building = production_lvl_2
 					has_building = production_lvl_3
 					has_building = counting_house
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
 			}
 		}

--- a/missions/ME_Byzantium_Missions.txt
+++ b/missions/ME_Byzantium_Missions.txt
@@ -62,53 +62,40 @@ BYZ_missions_1 = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
 				NOT = { base_production = 7 }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = production_lvl_2 }
-					NOT = { has_building = production_lvl_3 }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
 			owns_core_province = 362
 			362 = {
 				base_production = 7
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			owns_core_province = 2316
 			2316 = {
 				base_production = 7
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			owns_core_province = 363
 			363 = {
 				base_production = 7
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			owns_core_province = 4316
 			4316 = {
 				base_production = 7
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}
@@ -856,12 +843,7 @@ BYZ_missions_3 = {
 				NOT = { development = 40 }
 				NOT = { province_has_center_of_trade_of_level = 2 }
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = production_lvl_2 }
-					NOT = { has_building = production_lvl_3 }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
@@ -872,10 +854,10 @@ BYZ_missions_3 = {
 				development = 40
 				province_has_center_of_trade_of_level = 2
 				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
+					}
 					custom_trigger_tooltip = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 						province_has_building_of_group = { group = taxation all = yes }

--- a/missions/ME_Caspian_Minor_Missions.txt
+++ b/missions/ME_Caspian_Minor_Missions.txt
@@ -310,7 +310,10 @@ cpm_missions_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					has_building = workshop
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
+					}
 					trade_goods = silk
 				}
 				amount = 3
@@ -344,11 +347,9 @@ cpm_missions_5_bpi = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 					province_has_building_of_group = { group = trade all = yes }
 				}
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			capital_scope = {

--- a/missions/ME_Caspian_Minor_Missions.txt
+++ b/missions/ME_Caspian_Minor_Missions.txt
@@ -281,7 +281,10 @@ cpm_missions_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					has_building = marketplace
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
 					trade_goods = silk
 				}
 				amount = 2
@@ -337,8 +340,16 @@ cpm_missions_5_bpi = {
 		position = 2
 		trigger = {
 			4339 = {
-				has_building = marketplace
-				has_building = workshop
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
+				}
+				OR = {
+					has_building = workshop
+					has_building = production_lvl_2
+					has_building = production_lvl_3
+					has_building = counting_house
+				}
 			}
 			capital_scope = {
 				trade_share = {

--- a/missions/ME_Caucasia_Missions.txt
+++ b/missions/ME_Caucasia_Missions.txt
@@ -785,18 +785,16 @@ caucasia_missions_4 = {
 		trigger = {
 			owns = 428
 			428 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			owns = 2213
 			2213 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Caucasia_Missions.txt
+++ b/missions/ME_Caucasia_Missions.txt
@@ -107,10 +107,9 @@ caucasia_missions_2 = {
 			num_of_owned_provinces_with = {
 				value = 5
 				region = caucasia_region
-				OR = {
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+					province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 				}
 			}
 		}
@@ -475,22 +474,15 @@ caucasia_missions_3 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			owns_core_province = 330
 			330 = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}
@@ -512,11 +504,9 @@ caucasia_missions_3 = {
 			num_of_owned_provinces_with = {
 				value = 10
 				region = caucasia_region
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Corsica_Missions.txt
+++ b/missions/ME_Corsica_Missions.txt
@@ -953,10 +953,9 @@ corsica_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Corsica_Missions.txt
+++ b/missions/ME_Corsica_Missions.txt
@@ -929,9 +929,9 @@ corsica_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Corsica_Missions.txt
+++ b/missions/ME_Corsica_Missions.txt
@@ -408,11 +408,9 @@ corsica_missions_slot_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = dock
-						has_building = drydock
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+						province_has_building_of_group = { group = navy all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Croatia_Missions.txt
+++ b/missions/ME_Croatia_Missions.txt
@@ -423,13 +423,16 @@ Croatia_missions_4 = {
 			province_id = 137
 			OR = {
 				NOT = { owned_by = ROOT }
-				NOT = { has_building = stock_exchange }
+				NOT = { province_has_building_of_group = { group = trade equal_or_more_advanced_than = stock_exchange } }
 			}
 		}
 		trigger = {
 			137 = {
 				owned_by = ROOT
-				has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_stock_exchange
+					province_has_building_of_group = { group = trade equal_or_more_advanced_than = stock_exchange }
+				}
 			}
 		}
 		effect = {

--- a/missions/ME_Cyprus_Missions.txt
+++ b/missions/ME_Cyprus_Missions.txt
@@ -183,22 +183,15 @@ CYP_slot_2 = {
 			province_id = 320
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			320 = {
 				owned_by = ROOT
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			151 = {

--- a/missions/ME_Dagestan_Missions.txt
+++ b/missions/ME_Dagestan_Missions.txt
@@ -471,16 +471,12 @@ dagestan_missions_5 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
+					NOT = { province_has_building_of_group = { group = taxation all = yes } }
 					NOT = {
 						calc_true_if = {
 							all_province = {
 								area = dagestan_area
-								OR = {
-									has_building = temple
-									has_building = cathedral
-								}
+								NOT = { province_has_building_of_group = { group = taxation all = yes } }
 							}
 							amount = 3
 						}
@@ -496,9 +492,9 @@ dagestan_missions_5 = {
 			num_of_owned_provinces_with = {
 				value = 3
 				area = dagestan_area
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Dagestan_Missions.txt
+++ b/missions/ME_Dagestan_Missions.txt
@@ -352,22 +352,15 @@ dagestan_missions_4 = {
 			province_id = 419
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			owns = 419
 			419 = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_England_Great_Britain_Missions.txt
+++ b/missions/ME_England_Great_Britain_Missions.txt
@@ -1826,26 +1826,27 @@ ENG_missions_3_2 = {
 				area = yorkshire_area
 			}
 			province_has_center_of_trade_of_level = 1
-			NOT = { has_building = marketplace }
-			NOT = { has_building = trade_depot }
-			NOT = { has_building = stock_exchange }
+			NOT = { province_has_building_of_group = { group = trade all = yes } }
 		}
-        trigger = {
-			NOT = {
-				any_province = {
-					OR = {
-						area = home_counties_area
-						area = east_midlands_area
-						area = west_midlands_area
-						area = wessex_area
-						area = wales_area
-						area = east_anglia_area
-						area = yorkshire_area
-					}
-					province_has_center_of_trade_of_level = 1
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
+        # This mission is calling for a Marketplace+ in the provinces in England that have Centers of Trade
+		# A custom tooltip was needed as the double negative made this unreadable
+		trigger = {
+			custom_trigger_tooltip = {
+				tooltip = mission_market_place_with_asian_traders.t
+				NOT = {
+					any_province = {
+						OR = {
+							area = home_counties_area
+							area = east_midlands_area
+							area = west_midlands_area
+							area = wessex_area
+							area = wales_area
+							area = east_anglia_area
+							area = yorkshire_area
+						}
+						province_has_center_of_trade_of_level = 1
+						NOT = {	province_has_building_of_group = { group = trade all = yes } }
+					}	
 				}
 			}
 		}

--- a/missions/ME_England_Great_Britain_Missions.txt
+++ b/missions/ME_England_Great_Britain_Missions.txt
@@ -488,9 +488,14 @@ ENG_missions_1_3 = {
 				has_country_modifier = expand_navy 
 			}
 			naval_reformer = 1
-			OR = {
-				drydock = 1
-				dock = 1
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+					}
+				}
+				amount = 1
 			}
 		}
         effect = {
@@ -518,9 +523,14 @@ GBR_missions_1_3 = {
         required_missions = { ENG_Royal_Navy }
         position = 24
         trigger = {
-			OR = {
-				drydock = 10
-				dock = 10
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+					}
+				}
+				amount = 10
 			}
 			OR = {
 				shipyard = 10
@@ -1268,9 +1278,14 @@ ENG_missions_2_3 = {
 			}
 		}
         trigger = {
-			OR = {
-				drydock = 5
-				dock = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+					}
+				}
+				amount = 5
 			}
 			OR = {
 				shipyard = 5
@@ -1313,19 +1328,16 @@ GBR_missions_2_3 = {
 		provinces_to_highlight = {
 			province_id = 234
 			OR = {
-				AND = {
-					NOT = { has_building = drydock }
-					NOT = { has_building = dock }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 				NOT = { development = 10 }
 				NOT = { owned_by = ROOT }
 			}
 		}
         trigger = {
 			234 = {
-				OR = {
-					has_building = drydock
-					has_building = dock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
 				development = 10
 				owned_by = ROOT

--- a/missions/ME_England_Great_Britain_Missions.txt
+++ b/missions/ME_England_Great_Britain_Missions.txt
@@ -532,9 +532,14 @@ GBR_missions_1_3 = {
 				}
 				amount = 10
 			}
-			OR = {
-				shipyard = 10
-				grand_shipyard = 10
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
+					}
+				}
+				amount = 10
 			}
 			num_of_heavy_ship = 20
 		}
@@ -553,19 +558,16 @@ GBR_missions_1_3 = {
 		provinces_to_highlight = {
 			province_id = 4373
 			OR = {
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 				NOT = { development = 10 }
 				NOT = { owned_by = ROOT }
 			}
 		}
         trigger = {
 			4373 = {
-				OR = {
-					has_building = shipyard
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 				development = 10
 				owned_by = ROOT
@@ -1287,9 +1289,14 @@ ENG_missions_2_3 = {
 				}
 				amount = 5
 			}
-			OR = {
-				shipyard = 5
-				grand_shipyard = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
+					}
+				}
+				amount = 5
 			}
 			239 = {
 				owned_by = ROOT

--- a/missions/ME_Flanders_Missions.txt
+++ b/missions/ME_Flanders_Missions.txt
@@ -508,10 +508,14 @@ FLA_missions_5 = {
 			NOT = { owned_by = ROOT }
 		}
 		trigger = {
-			OR = {
-				marketplace = 2
-				trade_depot = 2
-				stock_exchange = 2
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 2
 			}
 			treasury = 100
 			owns = 1865

--- a/missions/ME_France_Missions.txt
+++ b/missions/ME_France_Missions.txt
@@ -1878,23 +1878,16 @@ FRA_missions_3 = {
 			province_id = 189
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 				NOT = { development = 24 }
 			}
 		}
 		trigger = {
 			189 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				development = 24
 			}

--- a/missions/ME_France_Missions.txt
+++ b/missions/ME_France_Missions.txt
@@ -127,11 +127,7 @@ FRA_missions_1 = {
 					NOT = { has_building = navyforcelimit_lvl_2 }
 					NOT = { has_building = grand_shipyard }
 				}
-				AND = {
-					NOT = { has_building = dock }
-					NOT = { has_building = navymanpower_lvl_2 }
-					NOT = { has_building = drydock }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 				NOT = { development = 15 }
 			}
 		}
@@ -143,10 +139,9 @@ FRA_missions_1 = {
 					has_building = navyforcelimit_lvl_2
 					has_building = grand_shipyard
 				}
-				OR = {
-					has_building = dock
-					has_building = navymanpower_lvl_2
-					has_building = drydock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
 				development = 15
 			}

--- a/missions/ME_France_Missions.txt
+++ b/missions/ME_France_Missions.txt
@@ -1095,12 +1095,7 @@ FRA_missions_2 = {
 							NOT = { has_building = cathedral }
 							NOT = { has_building = taxation_lvl_4 }
 						}
-						AND = {
-							NOT = { has_building = marketplace }
-							NOT = { has_building = trade_lvl_2 }
-							NOT = { has_building = trade_depot }
-							NOT = { has_building = stock_exchange }
-						}
+						NOT = { province_has_building_of_group = { group = trade all = yes } }
 						NOT = { development = 20 }
 					}
 				}
@@ -1119,11 +1114,9 @@ FRA_missions_2 = {
 					has_building = cathedral
 					has_building = taxation_lvl_4
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				development = 20
 			}
@@ -1327,22 +1320,15 @@ FRA_missions_2 = {
 			province_id = 167
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				}
 			}
-		}
 		trigger = {
 			167 = {
 				owned_by = ROOT
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_France_Missions.txt
+++ b/missions/ME_France_Missions.txt
@@ -1089,12 +1089,7 @@ FRA_missions_2 = {
 					province_id = 172
 					OR = {
 						NOT = { owned_by = ROOT }
-						AND = {
-							NOT = { has_building = temple }
-							NOT = { has_building = taxation_lvl_2 }
-							NOT = { has_building = cathedral }
-							NOT = { has_building = taxation_lvl_4 }
-						}
+						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 						NOT = { province_has_building_of_group = { group = trade all = yes } }
 						NOT = { development = 20 }
 					}
@@ -1108,11 +1103,9 @@ FRA_missions_2 = {
 			}
 			172 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_France_Missions.txt
+++ b/missions/ME_France_Missions.txt
@@ -122,11 +122,7 @@ FRA_missions_1 = {
 			province_id = 170
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = navyforcelimit_lvl_2 }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 				NOT = { development = 15 }
 			}
@@ -134,10 +130,9 @@ FRA_missions_1 = {
 		trigger = {
 			170 = {
 				owned_by = ROOT
-				OR = {
-					has_building = shipyard
-					has_building = navyforcelimit_lvl_2
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock

--- a/missions/ME_Franconia_Missions.txt
+++ b/missions/ME_Franconia_Missions.txt
@@ -63,10 +63,7 @@ Franconia_missions_1 = {
 							NOT = { has_building = workshop }
 							NOT = { has_building = counting_house }
 						}
-						AND = {
-							NOT = { has_building = temple }
-							NOT = { has_building = cathedral }
-						}
+						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 						AND = {
 							NOT = { has_building = barracks }
 							NOT = { has_building = training_fields }
@@ -91,9 +88,9 @@ Franconia_missions_1 = {
 					has_building = workshop
 					has_building = counting_house
 				}
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				OR = {
 					has_building = barracks
@@ -106,9 +103,9 @@ Franconia_missions_1 = {
 					has_building = workshop
 					has_building = counting_house
 				}
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				OR = {
 					has_building = barracks

--- a/missions/ME_Franconia_Missions.txt
+++ b/missions/ME_Franconia_Missions.txt
@@ -77,11 +77,8 @@ Franconia_missions_1 = {
 					province_id = 67
 					OR = {
 						NOT = { owned_by = ROOT }
-						AND = {
-							NOT = { has_building = marketplace }
-							NOT = { has_building = trade_depot }
-							NOT = { has_building = stock_exchange }
-						}
+						NOT = { province_has_building_of_group = { group = trade all = yes } }
+						
 					}
 				}
 			}
@@ -120,10 +117,9 @@ Franconia_missions_1 = {
 			}
 			67 = {
 				owned_by = ROOT
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Franconia_Missions.txt
+++ b/missions/ME_Franconia_Missions.txt
@@ -61,10 +61,7 @@ Franconia_missions_1 = {
 						NOT = { owned_by = ROOT }
 						NOT = { province_has_building_of_group = { group = production all = yes } }
 						NOT = { province_has_building_of_group = { group = taxation all = yes } }
-						AND = {
-							NOT = { has_building = barracks }
-							NOT = { has_building = training_fields }
-						}
+						NOT = { province_has_building_of_group = { group = manpower all = yes } }
 					}
 				}
 				AND = {
@@ -89,9 +86,9 @@ Franconia_missions_1 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
-				OR = {
-					has_building = barracks
-					has_building = training_fields
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+					province_has_building_of_group = { group = manpower all = yes }
 				}
 			}
 			71 = {
@@ -104,9 +101,9 @@ Franconia_missions_1 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
-				OR = {
-					has_building = barracks
-					has_building = training_fields
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+					province_has_building_of_group = { group = manpower all = yes }
 				}
 			}
 			67 = {

--- a/missions/ME_Franconia_Missions.txt
+++ b/missions/ME_Franconia_Missions.txt
@@ -59,10 +59,7 @@ Franconia_missions_1 = {
 					}
 					OR = {
 						NOT = { owned_by = ROOT }
-						AND = {
-							NOT = { has_building = workshop }
-							NOT = { has_building = counting_house }
-						}
+						NOT = { province_has_building_of_group = { group = production all = yes } }
 						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 						AND = {
 							NOT = { has_building = barracks }
@@ -84,9 +81,9 @@ Franconia_missions_1 = {
 			franconia_area = {
 				type = all
 				owned_by = ROOT
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
@@ -99,9 +96,9 @@ Franconia_missions_1 = {
 			}
 			71 = {
 				owned_by = ROOT
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL

--- a/missions/ME_Gaeldom_Missions.txt
+++ b/missions/ME_Gaeldom_Missions.txt
@@ -178,27 +178,27 @@ HSC_missions_1 = {
 				owned_by = ROOT
 			}
 			munster_area = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			connacht_area = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			ulster_area = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			leinster_area = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}

--- a/missions/ME_Gaeldom_Missions.txt
+++ b/missions/ME_Gaeldom_Missions.txt
@@ -280,10 +280,7 @@ HSC_missions_2 = {
 					NOT = { has_building = regimental_camp }
 					NOT = { has_building = conscription_center }
 				}
-				AND = {
-					NOT = { has_building = barracks }
-					NOT = { has_building = training_fields }
-				}
+				NOT = { province_has_building_of_group = { group = manpower all = yes } }
 			}
 		}
 		trigger = {
@@ -298,9 +295,9 @@ HSC_missions_2 = {
 					has_building = regimental_camp
 					has_building = conscription_center
 				}
-				OR = {
-					has_building = barracks
-					has_building = training_fields
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+					province_has_building_of_group = { group = manpower all = yes }
 				}
 			}
 			mil_power = 400

--- a/missions/ME_Gaeldom_Missions.txt
+++ b/missions/ME_Gaeldom_Missions.txt
@@ -276,10 +276,7 @@ HSC_missions_2 = {
 					NOT = { has_building = fort_17th }
 					NOT = { has_building = fort_18th }
 				}
-				AND = {
-					NOT = { has_building = regimental_camp }
-					NOT = { has_building = conscription_center }
-				}
+				NOT = { province_has_building_of_group = { group = forcelimit all = yes } }
 				NOT = { province_has_building_of_group = { group = manpower all = yes } }
 			}
 		}
@@ -291,9 +288,9 @@ HSC_missions_2 = {
 					has_building = fort_17th
 					has_building = fort_18th
 				}
-				OR = {
-					has_building = regimental_camp
-					has_building = conscription_center
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL

--- a/missions/ME_Gaeldom_Missions.txt
+++ b/missions/ME_Gaeldom_Missions.txt
@@ -271,10 +271,11 @@ HSC_missions_2 = {
 			area = wales_area
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
+				NOT = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+						province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
+					}
 				}
 				NOT = { province_has_building_of_group = { group = forcelimit all = yes } }
 				NOT = { province_has_building_of_group = { group = manpower all = yes } }
@@ -283,10 +284,9 @@ HSC_missions_2 = {
 		trigger = {
 			wales_area = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+					province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL

--- a/missions/ME_Gaeldom_Missions.txt
+++ b/missions/ME_Gaeldom_Missions.txt
@@ -364,10 +364,7 @@ HSC_missions_3 = {
 			area = brittany_area
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 			}
 		}
@@ -375,9 +372,9 @@ HSC_missions_3 = {
 			brittany_area = {
 				type = all
 				owned_by = ROOT
-				OR = {
-					has_building = shipyard
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock

--- a/missions/ME_Gaeldom_Missions.txt
+++ b/missions/ME_Gaeldom_Missions.txt
@@ -368,10 +368,7 @@ HSC_missions_3 = {
 					NOT = { has_building = shipyard }
 					NOT = { has_building = grand_shipyard }
 				}
-				AND = {
-					NOT = { has_building = dock }
-					NOT = { has_building = drydock }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 			}
 		}
 		trigger = {
@@ -382,9 +379,9 @@ HSC_missions_3 = {
 					has_building = shipyard
 					has_building = grand_shipyard
 				}
-				OR = {
-					has_building = dock
-					has_building = drydock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
 			}
 			dip_power = 500

--- a/missions/ME_Galicia_Missions.txt
+++ b/missions/ME_Galicia_Missions.txt
@@ -35,21 +35,14 @@ GAL_missions_1 = {
 			province_id = 206
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			206 = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}

--- a/missions/ME_Gazikumukh_Missions.txt
+++ b/missions/ME_Gazikumukh_Missions.txt
@@ -166,22 +166,15 @@ gazikumukh_missions_3 = {
 			province_id = 2198
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			2198 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Generic_Hansa_Missions.txt
+++ b/missions/ME_Generic_Hansa_Missions.txt
@@ -325,9 +325,14 @@ generic_hansa_missions_4 = {
 		required_missions = { generic_hsa_army }
 		position = 2
 		trigger = {
-			OR = {
-				barracks = 1
-				training_fields = 1
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
+					}
+				}
+				amount = 1
 			}
 			num_of_mercenaries = 5
 		}

--- a/missions/ME_Generic_Persian_Missions.txt
+++ b/missions/ME_Generic_Persian_Missions.txt
@@ -41,19 +41,14 @@ Generic_Persian_Missions_PER_1 = {
 					has_building = counting_house
 				}
 			}
-			NOT = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
-				}
-			}
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			NOT = { province_has_building_of_group = { group = trade all = yes } }
 		}
         trigger = {
 			capital_scope = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				OR = {
 					has_building = workshop
@@ -859,20 +854,15 @@ Generic_Persian_Missions_YZD = {
         position = 4
 		provinces_to_highlight = {
 			province_id = 433
-			NOT = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
-				}
-			}
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			NOT = { owned_by = ROOT }
 			NOT = { development = 30 }
 		}
         trigger = {
 			433 = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				development = 30
 				owned_by = ROOT

--- a/missions/ME_Generic_Persian_Missions.txt
+++ b/missions/ME_Generic_Persian_Missions.txt
@@ -606,23 +606,14 @@ Generic_Persian_Missions_SIS = {
 		provinces_to_highlight = {
 			province_id = 435
 			NOT = { owned_by = ROOT }
-			NOT = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
-				}
+			NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
-		}
         trigger = {
 			435 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Generic_Persian_Missions.txt
+++ b/missions/ME_Generic_Persian_Missions.txt
@@ -47,13 +47,7 @@ Generic_Persian_Missions_PER_1 = {
 					has_building = cathedral
 				}
 			}
-			NOT = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
-				}
-			}
+			NOT = { province_has_building_of_group = { group = trade all = yes } }
 		}
         trigger = {
 			capital_scope = {
@@ -65,10 +59,9 @@ Generic_Persian_Missions_PER_1 = {
 					has_building = workshop
 					has_building = counting_house
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Generic_Persian_Missions.txt
+++ b/missions/ME_Generic_Persian_Missions.txt
@@ -35,12 +35,7 @@ Generic_Persian_Missions_PER_1 = {
         position = 3
 		provinces_to_highlight = {
 			is_capital_of = ROOT
-			NOT = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
-				}
-			}
+			NOT = { province_has_building_of_group = { group = production all = yes } }
 			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			NOT = { province_has_building_of_group = { group = trade all = yes } }
 		}
@@ -50,9 +45,9 @@ Generic_Persian_Missions_PER_1 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_Generic_Rhenish_Missions.txt
+++ b/missions/ME_Generic_Rhenish_Missions.txt
@@ -407,11 +407,14 @@ generic_rhenish_missions_4 = {
 		required_missions = { }
 		position = 1
 		trigger = {
-			OR = {
-				temple = 1
- 				taxation_lvl_2 = 1
-				cathedral = 1
- 				taxation_lvl_4 = 1
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
+				}
+				amount = 1
 			}
 		}
 		effect = {

--- a/missions/ME_Generic_Rhenish_Missions.txt
+++ b/missions/ME_Generic_Rhenish_Missions.txt
@@ -340,11 +340,14 @@ generic_rhenish_missions_3 = {
 		required_missions = { rhn_generic_treasury rhn_generic_marketplace rhn_generic_church }
 		position = 2
 		trigger = {
-			OR = {
-				workshop = 1
- 				production_lvl_2 = 1
-				counting_house = 1
- 				production_lvl_3 = 1
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
+					}
+				}
+				amount = 1
 			}
 		}
 		effect = {

--- a/missions/ME_Generic_Rhenish_Missions.txt
+++ b/missions/ME_Generic_Rhenish_Missions.txt
@@ -313,10 +313,14 @@ generic_rhenish_missions_3 = {
 		required_missions = { }
 		position = 1
 		trigger = {
-			OR = {
-				marketplace = 1
-				trade_depot = 1
-				stock_exchange = 1
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 1
 			}
 		}
 		effect = {

--- a/missions/ME_Generic_Rhenish_Missions.txt
+++ b/missions/ME_Generic_Rhenish_Missions.txt
@@ -561,9 +561,9 @@ generic_rhenish_missions_5 = {
 			else = {
 				capital_scope = {
 					development = 15
-					OR = {
-						has_building = courthouse
-						has_building = town_hall
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+						province_has_building_of_group = { group = government all = yes }
 					}
 				}
 			}

--- a/missions/ME_Germany_Missions.txt
+++ b/missions/ME_Germany_Missions.txt
@@ -692,9 +692,14 @@ GER_missions_3 = {
 		icon = me_mission_army
 		position = 6
 		trigger = {
-			OR = {
-				regimental_camp = 20
-				conscription_center = 20
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL
+						province_has_building_of_group = { group = forcelimit all = yes }
+					}
+				}
+				amount = 20
 			}
 			OR = {
 				full_idea_group = quantity_ideas
@@ -706,10 +711,7 @@ GER_missions_3 = {
 				limit = {
 					culture_group = ROOT
 					NOT = { has_province_modifier = germany_german_conscription_system_province_modifier }
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_province_modifier = {
 					name = germany_german_conscription_system_province_modifier
@@ -720,10 +722,7 @@ GER_missions_3 = {
 				limit = {
 					culture_group = ROOT
 					NOT = { has_province_modifier = germany_german_conscription_system_province_modifier }
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_province_modifier = {
 					name = germany_german_conscription_system_province_modifier
@@ -734,10 +733,7 @@ GER_missions_3 = {
 				limit = {
 					culture_group = ROOT
 					NOT = { has_province_modifier = germany_german_conscription_system_province_modifier }
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_province_modifier = {
 					name = germany_german_conscription_system_province_modifier
@@ -748,10 +744,7 @@ GER_missions_3 = {
 				limit = {
 					culture_group = ROOT
 					NOT = { has_province_modifier = germany_german_conscription_system_province_modifier }
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_province_modifier = {
 					name = germany_german_conscription_system_province_modifier
@@ -762,10 +755,7 @@ GER_missions_3 = {
 				limit = {
 					culture_group = ROOT
 					NOT = { has_province_modifier = germany_german_conscription_system_province_modifier }
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_province_modifier = {
 					name = germany_german_conscription_system_province_modifier
@@ -774,91 +764,61 @@ GER_missions_3 = {
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_base_manpower = 1
 			}

--- a/missions/ME_Germany_Missions.txt
+++ b/missions/ME_Germany_Missions.txt
@@ -930,9 +930,14 @@ GER_missions_4 = {
 		position = 5
 		trigger = {
 			share_of_starting_income = 3
-			OR = {
-				shipyard = 15
-				grand_shipyard = 15
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
+					}
+				}
+				amount = 15
 			}
 			OR = {
 				any_rival_country = {

--- a/missions/ME_Granada_Andalusia_Missions.txt
+++ b/missions/ME_Granada_Andalusia_Missions.txt
@@ -584,15 +584,16 @@ GRA_ADU_missions_5 = {
 			province_id = 225
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
-				NOT = { has_building = cathedral }
-				NOT = { has_building = taxation_lvl_4 }
+				NOT = { province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral } }
 			}
 		}
 		trigger = {
 			225 = {
 				country_or_non_sovereign_subject_holds = ROOT
-				has_building = cathedral
-				has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
+						province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral }
+				}
 			}
 		}
 		effect = {

--- a/missions/ME_Granada_Andalusia_Missions.txt
+++ b/missions/ME_Granada_Andalusia_Missions.txt
@@ -640,23 +640,16 @@ GRA_ADU_missions_5 = {
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				NOT = { global_trade = 100 }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = production_lvl_2 }
-					NOT = { has_building = production_lvl_3 }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 				NOT = { development = 40 }
 			}
 		}
 		trigger = {
 			225 = {
 				country_or_non_sovereign_subject_holds = ROOT
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				global_trade = 100
 				development = 40

--- a/missions/ME_Great_Horde_Missions.txt
+++ b/missions/ME_Great_Horde_Missions.txt
@@ -50,33 +50,24 @@ Great_Horde_missions_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			285 = {
 				owned_by = ROOT
 				is_core = ROOT
-				OR {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			286 = {
 				owned_by = ROOT
 				is_core = ROOT
-				OR {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Great_Horde_Missions.txt
+++ b/missions/ME_Great_Horde_Missions.txt
@@ -382,43 +382,32 @@ Great_Horde_missions_3 = {
 			}
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			astrakhan_area = {
 				type = all
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			saratov_area = {
 				type = all
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			lower_don_area = {
 				type = all
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Hisn_Kayfa_Ayyubid_Missions.txt
+++ b/missions/ME_Hisn_Kayfa_Ayyubid_Missions.txt
@@ -1106,44 +1106,41 @@ HSN_AYY_missions_4 = {
 				province_id = 4282
 			}
 			NOT = { country_or_non_sovereign_subject_holds = ROOT }
-			OR = {
-				NOT = { has_building = workshop }
-				NOT = { has_building = counting_house }
-			}
+			NOT = { province_has_building_of_group = { group = production all = yes } }
 		}
 		trigger = {
 			387 = {
-				OR = { 
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}
 			386 = {
-				OR = { 
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}
 			4280 = {
-				OR = { 
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}
 			4279 = {
-				OR = { 
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}
 			4282 = {
-				OR = { 
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}

--- a/missions/ME_Hisn_Kayfa_Ayyubid_Missions.txt
+++ b/missions/ME_Hisn_Kayfa_Ayyubid_Missions.txt
@@ -902,26 +902,17 @@ HSN_AYY_missions_4 = {
 				region = caucasia_region
 			}
 			owned_by = ROOT
-			NOT = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
-				}
+			NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
-		}
 		trigger = {
 			num_of_owned_provinces_with = {
 				OR = {
 					region = anatolia_region
 					region = caucasia_region
 				}
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				value = 3
 			}

--- a/missions/ME_Hisn_Kayfa_Ayyubid_Missions.txt
+++ b/missions/ME_Hisn_Kayfa_Ayyubid_Missions.txt
@@ -1353,16 +1353,24 @@ HSN_AYY_missions_5 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 30 }
-				NOT = { has_building = temple }
-				NOT = { has_building = marketplace }
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			410 = {
 				development = 30
-				has_building = temple
 				owned_by = ROOT
-				has_building = marketplace
+				OR = {
+					has_building = temple
+					has_building = taxation_lvl_2
+					has_building = cathedral
+					has_building = taxation_lvl_4
+				}
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
+				}
 			}
 		}
 		effect = {

--- a/missions/ME_Hisn_Kayfa_Ayyubid_Missions.txt
+++ b/missions/ME_Hisn_Kayfa_Ayyubid_Missions.txt
@@ -583,10 +583,7 @@ HSN_AYY_missions_3 = {
 			province_id = 377
 			OR = {
 				NOT = { development = 30 }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { owned_by = ROOT }
 			}
 		}
@@ -594,9 +591,9 @@ HSN_AYY_missions_3 = {
 			377 = {
 				owned_by = ROOT
 				development = 30
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -697,12 +694,7 @@ HSN_AYY_missions_3 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 20 }
-				NOT = { 
-					AND = {
-						has_building = temple
-						has_building = cathedral
-					}
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
@@ -711,17 +703,17 @@ HSN_AYY_missions_3 = {
 					384 = {
 						owned_by = ROOT
 						development = 20
-						OR = {
-							has_building = temple
-							has_building = cathedral
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+							province_has_building_of_group = { group = taxation all = yes }
 						}
 					}
 					385 = {
 						owned_by = ROOT
 						development = 20
-						OR = {
-							has_building = temple
-							has_building = cathedral
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+							province_has_building_of_group = { group = taxation all = yes }
 						}
 					}
 				}
@@ -1033,14 +1025,17 @@ HSN_AYY_missions_4 = {
 		provinces_to_highlight = {
 			province_id = 382
 			NOT = { development = 30 }
-			NOT = { has_building = temple }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			NOT = { owned_by = ROOT }
 		}
 		trigger = {
 			382 = {
 				owned_by = ROOT
 				development = 30
-				has_building = temple
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
+				}
 			}
 		}
 		effect = {
@@ -1296,13 +1291,16 @@ HSN_AYY_missions_5 = {
 			province_id = 4295
 			OR = {
 				NOT = { development = 15 }
-				NOT = { has_building = temple }
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			4295 = {
 				development = 15
-				has_building = temple
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
+				}
 			}
 		}
 		effect = {
@@ -1320,18 +1318,17 @@ HSN_AYY_missions_5 = {
 		position = 3
 		provinces_to_highlight = {
 			owned_by = ROOT
-			OR = {
-				NOT = { has_building = temple }
-				NOT = { has_building = cathedral }
-			}
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 		}
 		trigger = {
-			num_of_owned_provinces_with = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
-				value = 5
+				amount = 5
 			}
 		}
 		effect = {
@@ -1361,11 +1358,9 @@ HSN_AYY_missions_5 = {
 			410 = {
 				development = 30
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_Hosokawa_Missions.txt
+++ b/missions/ME_Hosokawa_Missions.txt
@@ -47,10 +47,7 @@ HSK_missions_1 = {
 			province_id = 1020
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 			ROOT = {
 				NOT = {
@@ -66,9 +63,9 @@ HSK_missions_1 = {
 			OR = {
 				1020 = {
 					owned_by = ROOT
-					OR = {
-						has_building = temple
-						has_building = cathedral
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 				}
 				reverse_has_opinion_modifier = {
@@ -158,12 +155,14 @@ HSK_missions_2 = {
 		position = 3
 		required_missions = { }
 		trigger = {
-			num_of_owned_provinces_with =  {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
-				value = 3
+				amount = 3
 			}
 		}
 		effect = {

--- a/missions/ME_Hosokawa_Missions.txt
+++ b/missions/ME_Hosokawa_Missions.txt
@@ -181,19 +181,16 @@ HSK_missions_2 = {
 			province_id = 1020
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = courthouse }
-					NOT = { has_building = town_hall }
-				}
+				NOT = { province_has_building_of_group = { group = government all = yes } }
 			}
 		}
 		trigger = {
 		
 			1020 = {
 				owned_by = ROOT
-				OR = {
-					has_building = courthouse
-					has_building = town_hall
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+					province_has_building_of_group = { group = government all = yes }
 				}
 			}
 		}

--- a/missions/ME_Hungary_Missions.txt
+++ b/missions/ME_Hungary_Missions.txt
@@ -104,22 +104,15 @@ HUN_missions_slot_1 = {
 			province_id = 137
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			owns = 137
 			137 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}
@@ -917,23 +910,16 @@ HUN_missions_slot_4 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { base_production = 10 }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			owns = 153
 			153 = {
 				base_production = 10
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Iceland_Missions.txt
+++ b/missions/ME_Iceland_Missions.txt
@@ -271,13 +271,16 @@ ICE_missions_5 = {
 			province_id = 370
 			OR = {
 				NOT = { owned_by = ROOT }
-				NOT = { has_building = cathedral }
+				NOT = { province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral } }
 			}
 		}
 		trigger = {
 			370 = {
 				owned_by = ROOT
-				has_building = cathedral
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
+						province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral }
+					}
 			}
 		}
 		effect = {

--- a/missions/ME_Inca_Missions.txt
+++ b/missions/ME_Inca_Missions.txt
@@ -2183,12 +2183,14 @@ inca_missions_4 = {
 		required_missions = { inca_solar_cult }
 		position = 2
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 15
-				OR = {
-					has_building = temple
-					has_building = cathedral
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
+				amount = 15
 			}
 		}
 		effect = {
@@ -2212,9 +2214,14 @@ inca_missions_4 = {
 		required_missions = { inca_temples_for_viracocha }
 		position = 3
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 15
-				has_building = cathedral
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
+						province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral }
+					}
+				}
+				amount = 15
 			}
 		}
 		effect = {

--- a/missions/ME_Inca_Missions.txt
+++ b/missions/ME_Inca_Missions.txt
@@ -212,12 +212,14 @@ inca_missions_1 = {
 		required_missions = { inca_fortification_efforts }
 		position = 9
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 15
-				OR = {
-					has_building = barracks
-					has_building = training_fields
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
+					}
 				}
+				amount = 15
 			}
 		}
 		effect = {

--- a/missions/ME_Inca_Missions.txt
+++ b/missions/ME_Inca_Missions.txt
@@ -1791,14 +1791,13 @@ inca_missions_3 = {
 		position = 6
 		provinces_to_highlight = {
 			is_capital_of = ROOT
-			NOT = { has_building = courthouse }
-			NOT = { has_building = town_hall }
+			NOT = { province_has_building_of_group = { group = government all = yes } }
 		}
 		trigger = {
 			capital_scope = {
-				OR = {
-					has_building = courthouse
-					has_building = town_hall
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+					province_has_building_of_group = { group = government all = yes }
 				}
 			}
 		}

--- a/missions/ME_Inca_Missions.txt
+++ b/missions/ME_Inca_Missions.txt
@@ -2354,12 +2354,14 @@ inca_missions_4 = {
 		required_missions = { }
 		position = 8
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 15
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
+					}
 				}
+				amount = 15
 			}
 		}
 		effect = {

--- a/missions/ME_Inca_Missions.txt
+++ b/missions/ME_Inca_Missions.txt
@@ -1170,27 +1170,20 @@ inca_missions_2 = {
 		position = 8
 		provinces_to_highlight = {
 			is_capital_of = ROOT
-			NOT = { has_building = fort_15th }
-			NOT = { has_building = fort_16th }
-			NOT = { has_building = fort_17th }
-			NOT = { has_building = fort_18th }
+			NOT = { province_has_building_of_group = { group = defense all = yes } }
 		}
 		trigger = {
 			num_of_owned_provinces_with = {
 				value = 5
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			capital_scope = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}
@@ -1201,11 +1194,9 @@ inca_missions_2 = {
 			}
 			every_owned_province = {
 				limit = {
-					OR = {
-						has_building = fort_15th
-						has_building = fort_16th
-						has_building = fort_17th
-						has_building = fort_18th
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+						province_has_building_of_group = { group = defense all = yes }
 					}
 				}
 				add_province_modifier = {

--- a/missions/ME_Inca_Missions.txt
+++ b/missions/ME_Inca_Missions.txt
@@ -1121,13 +1121,14 @@ inca_missions_2 = {
 		required_missions = { inca_roads_in_chinchansuyu }
 		position = 7
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 15
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
 				}
+				amount = 15
 			}
 		}
 		effect = {
@@ -1135,21 +1136,13 @@ inca_missions_2 = {
 			if = {
 				limit = {
 					any_owned_province = {
-						OR = {
-							has_building = marketplace
-							has_building = trade_depot
-							has_building = stock_exchange
-						}
+						province_has_building_of_group = { group = trade all = yes }
 						NOT = { province_has_center_of_trade_of_level = 1 }
 					}
 				}
 				random_owned_province = {
 					limit = {
-						OR = {
-							has_building = marketplace
-							has_building = trade_depot
-							has_building = stock_exchange
-						}
+						province_has_building_of_group = { group = trade all = yes }
 						NOT = { province_has_center_of_trade_of_level = 1 }
 					}
 					center_of_trade = 1				
@@ -1157,11 +1150,7 @@ inca_missions_2 = {
 			}
 			every_owned_province = {
 				limit = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
-					}
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				add_trade_modifier = {
 					who = ROOT

--- a/missions/ME_Ireland_Missions.txt
+++ b/missions/ME_Ireland_Missions.txt
@@ -461,10 +461,14 @@ ireland_missions_column_3 = {
 		required_missions = { ireland_mission_4 }
 		position = 3
 		trigger = {
-			OR = {
-				marketplace = 7
-				trade_depot = 7
-				stock_exchange = 7
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 7
 			}
 		}
 		effect = {

--- a/missions/ME_Ireland_Missions.txt
+++ b/missions/ME_Ireland_Missions.txt
@@ -647,9 +647,14 @@ ireland_missions_column_4 = {
 		required_missions = { ireland_mission_1 }
 		position = 2
 		trigger = {
-			OR = {
-				barracks = 7
-				training_fields = 7
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
+					}
+				}
+				amount = 7
 			}
 		}
 		effect = {

--- a/missions/ME_Irish_Minors_Missions.txt
+++ b/missions/ME_Irish_Minors_Missions.txt
@@ -243,10 +243,14 @@ ME_irish_minors_missions_3 = {
 		required_missions = { Ireland_Minor_Amass_Wealth }
 		position = 3
 		trigger = {
-			OR = {
-				marketplace = 3
-				trade_depot = 3
-				stock_exchange = 3
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 3
 			}
 		}
 		effect = {

--- a/missions/ME_Irish_Minors_Missions.txt
+++ b/missions/ME_Irish_Minors_Missions.txt
@@ -271,9 +271,14 @@ ME_irish_minors_missions_3 = {
 		required_missions = { Ireland_Minor_Marketplaces Ireland_Minor_Buildings }
 		position = 4
 		trigger = {
-			OR = {
-				shipyard = 3
-				grand_shipyard = 3
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
+					}
+				}
+				amount = 3
 			}
 		}
 		effect = {

--- a/missions/ME_Irish_Minors_Missions.txt
+++ b/missions/ME_Irish_Minors_Missions.txt
@@ -136,9 +136,14 @@ ME_irish_minors_missions_2 = {
 		required_missions = { Ireland_Minor_Amass_Wealth }
 		position = 3
 		trigger = {
-			OR = {
-				barracks = 3
-				training_fields = 3
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
+					}
+				}
+				amount = 3
 			}
 		}
 		effect = {

--- a/missions/ME_Italy_Missions.txt
+++ b/missions/ME_Italy_Missions.txt
@@ -40,50 +40,37 @@ Italian_missions_1 = {
 			}
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			104 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			1875 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			OR = {
 				1774 = {
 					owned_by = ROOT
-					OR = {
-						has_building = fort_15th
-						has_building = fort_16th
-						has_building = fort_17th
-						has_building = fort_18th
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+						province_has_building_of_group = { group = defense all = yes }
 					}
 				}
 				110 = {
 					owned_by = ROOT
-					OR = {
-						has_building = fort_15th
-						has_building = fort_16th
-						has_building = fort_17th
-						has_building = fort_18th
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+						province_has_building_of_group = { group = defense all = yes }
 					}
 				}
 			}
@@ -724,26 +711,19 @@ Italian_missions_2 = {
 				province_id = 210
 				province_id = 197
 			}
-			NOT = { has_building = fort_15th }
-			NOT = { has_building = fort_16th }
-			NOT = { has_building = fort_17th }
-			NOT = { has_building = fort_18th }
+			NOT = { province_has_building_of_group = { group = defense all = yes } }
 		}
 		trigger = {
 			210 = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			197 = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Japan_Missions.txt
+++ b/missions/ME_Japan_Missions.txt
@@ -2160,21 +2160,16 @@ japan_missions_2_colonial = {
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				NOT = { development = 10 }
-				AND = {
-					NOT = { has_building = dock }
-					NOT = { has_building = navymanpower_lvl_2 }
-					NOT = { has_building = drydock }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 			}
 		}
 		trigger = {
 			owns_or_non_sovereign_subject_of = 1015
 			1015 = {
 				development = 10
-				OR = {
-					has_building = dock
-					has_building = navymanpower_lvl_2
-					has_building = drydock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
 			}
 		}
@@ -2474,11 +2469,7 @@ japan_missions_3_colonial = {
 					NOT = { has_building = navyforcelimit_lvl_2 }
 					NOT = { has_building = grand_shipyard }
 				}
-				AND = {
-					NOT = { has_building = dock }
-					NOT = { has_building = navymanpower_lvl_2 }
-					NOT = { has_building = drydock }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 				NOT = { development = 25 }
 			}
 			ROOT = {
@@ -2491,10 +2482,9 @@ japan_missions_3_colonial = {
 							has_building = navyforcelimit_lvl_2
 							has_building = grand_shipyard
 						}
-						OR = {
-							has_building = dock
-							has_building = navymanpower_lvl_2
-							has_building = drydock
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+							province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 						}
 						development = 25
 					}
@@ -2506,9 +2496,14 @@ japan_missions_3_colonial = {
 				shipyard = 25
 				grand_shipyard = 25
 			}
-			OR = {
-				dock = 15
-				drydock = 15
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+					}
+				}
+				amount = 15
 			}
 			num_of_owned_provinces_with = {
 				value = 5
@@ -2518,10 +2513,9 @@ japan_missions_3_colonial = {
 					has_building = navyforcelimit_lvl_2
 					has_building = grand_shipyard
 				}
-				OR = {
-					has_building = dock
-					has_building = navymanpower_lvl_2
-					has_building = drydock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
 				development = 25
 			}
@@ -2758,9 +2752,14 @@ japan_missions_5_colonial = {
 		position = 11
 		trigger = {
 			navy_size_percentage = 1
-			OR = {
-				dock = 10
-				drydock = 10
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+					}
+				}
+				amount = 10
 			}
 			OR = {
 				shipyard = 10

--- a/missions/ME_Japan_Missions.txt
+++ b/missions/ME_Japan_Missions.txt
@@ -2464,11 +2464,7 @@ japan_missions_3_colonial = {
 		provinces_to_highlight = {
 			region = japan_region
 			OR = {
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = navyforcelimit_lvl_2 }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 				NOT = { development = 25 }
 			}
@@ -2477,10 +2473,9 @@ japan_missions_3_colonial = {
 					num_of_owned_provinces_with = {
 						value = 5
 						region = japan_region
-						OR = {
-							has_building = shipyard
-							has_building = navyforcelimit_lvl_2
-							has_building = grand_shipyard
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+							province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 						}
 						custom_trigger_tooltip = {
 							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
@@ -2492,9 +2487,14 @@ japan_missions_3_colonial = {
 			}
 		}
 		trigger = {
-			OR = {
-				shipyard = 25
-				grand_shipyard = 25
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
+					}
+				}
+				amount = 25
 			}
 			calc_true_if = {
 				all_owned_province = {
@@ -2508,10 +2508,9 @@ japan_missions_3_colonial = {
 			num_of_owned_provinces_with = {
 				value = 5
 				region = japan_region
-				OR = {
-					has_building = shipyard
-					has_building = navyforcelimit_lvl_2
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
@@ -2761,9 +2760,14 @@ japan_missions_5_colonial = {
 				}
 				amount = 10
 			}
-			OR = {
-				shipyard = 10
-				grand_shipyard = 10
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
+					}
+				}
+				amount = 10
 			}
 		}
 		effect = {

--- a/missions/ME_Japan_Missions.txt
+++ b/missions/ME_Japan_Missions.txt
@@ -824,10 +824,14 @@ japan_missions_4 = {
 		required_missions = { japan_issue_a_new_coin }
 		position = 5
 		trigger = {
-			OR = {
-				marketplace = 10
-				trade_depot = 10
-				stock_exchange = 10
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 10
 			}
 			if = {
 				limit = {

--- a/missions/ME_Jerusalem_Missions.txt
+++ b/missions/ME_Jerusalem_Missions.txt
@@ -626,11 +626,9 @@ KOJ_missions_4 = {
 		trigger = {
 			num_of_owned_provinces_with = {
 				value = 10
-				OR = {
-					has_building = courthouse
-					has_building = town_hall
-					has_building = government_lvl_3
-					has_building = government_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+					province_has_building_of_group = { group = government all = yes }
 				}
 			}
 			estate_influence = {
@@ -809,7 +807,15 @@ KOJ_missions_5 = {
 				}
 			}
 			else = {
-				town_hall = 10
+				calc_true_if = {
+					all_owned_province = {
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_EOMAT_town_hall
+							province_has_building_of_group = { group = government equal_or_more_advanced_than = town_hall }
+						}
+					}
+					amount = 10
+				}
 			}
 		}
 		effect = {

--- a/missions/ME_Jerusalem_Missions.txt
+++ b/missions/ME_Jerusalem_Missions.txt
@@ -786,14 +786,14 @@ KOJ_missions_5 = {
 		required_missions = { koj_abu_haneefa }
 		trigger = {
 			NOT = { unrest = 0.01 }
-			num_of_owned_provinces_with = {
-				value = 10
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
+				amount = 10
 			}
 			if = {
 				limit = {

--- a/missions/ME_Karelia_Missions.txt
+++ b/missions/ME_Karelia_Missions.txt
@@ -129,13 +129,16 @@ karelia_missions_1 = {
 			province_id = 309
 			OR = {
 				NOT = { owned_by = ROOT }
-				NOT = { has_building = cathedral }
+				NOT = { province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral } }
 			}
 		}
 		trigger = {
 			309 = {
 				owned_by = ROOT
-				has_building = cathedral
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
+						province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral }
+					}
 			}
 		}
 		effect = {
@@ -156,14 +159,17 @@ karelia_missions_1 = {
 			province_id = 32
 			OR = {
 				NOT = { owned_by = ROOT }
-				NOT = { has_building = cathedral }
+				NOT = { province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral } }
 				NOT = { fort_level = 4 }
 			}
 		}
 		trigger = {
 			32 = {
 				owned_by = ROOT
-				has_building = cathedral
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
+						province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral }
+					}
 				fort_level = 4
 			}
 		}

--- a/missions/ME_Kazan_Tatarstan_Missions.txt
+++ b/missions/ME_Kazan_Tatarstan_Missions.txt
@@ -2768,10 +2768,7 @@ TRN_missions_2 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 				AND = {
 					has_dlc = "Common Sense"
 					NOT = { base_production = 10 }
@@ -2786,9 +2783,9 @@ TRN_missions_2 = {
 			466 = {#sarai
 				owned_by = ROOT
 				is_core = ROOT
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				if = {
 					limit = {
@@ -2803,9 +2800,9 @@ TRN_missions_2 = {
 			1082 = {#kazan
 				owned_by = ROOT
 				is_core = ROOT
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				if = {
 					limit = {
@@ -2820,9 +2817,9 @@ TRN_missions_2 = {
 			4265 = {#archally
 				owned_by = ROOT
 				is_core = ROOT
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				if = {
 					limit = {
@@ -2837,9 +2834,9 @@ TRN_missions_2 = {
 			295 = {#moscow
 				owned_by = ROOT
 				is_core = ROOT
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				if = {
 					limit = {
@@ -2854,9 +2851,9 @@ TRN_missions_2 = {
 			464 = {#astrakhan
 				owned_by = ROOT
 				is_core = ROOT
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				if = {
 					limit = {

--- a/missions/ME_Kazan_Tatarstan_Missions.txt
+++ b/missions/ME_Kazan_Tatarstan_Missions.txt
@@ -2594,9 +2594,14 @@ TRN_missions_1 = {
 				value = 20
 				fort_level = 2
 			}
-			OR = {
-				barracks = 40
-				training_fields = 40
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
+					}
+				}
+				amount = 40
 			}
 		}
 		effect = {
@@ -2646,10 +2651,7 @@ TRN_missions_1 = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
 				NOT = { province_has_building_of_group = { group = trade all = yes }}
-				AND = {
-					NOT = { has_building = barracks }
-					NOT = { has_building = training_fields }
-				}
+				NOT = { province_has_building_of_group = { group = manpower all = yes } }
 				NOT = { fort_level = 4 }
 				AND = {
 					has_dlc = "Common Sense"
@@ -2670,9 +2672,9 @@ TRN_missions_1 = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 						province_has_building_of_group = { group = trade all = yes }
 					}
-					OR = {
-						has_building = barracks
-						has_building = training_fields
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
 					}
 					fort_level = 4
 					if = {
@@ -2695,9 +2697,9 @@ TRN_missions_1 = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 						province_has_building_of_group = { group = trade all = yes }
 					}
-					OR = {
-						has_building = barracks
-						has_building = training_fields
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
 					}
 					fort_level = 4
 					if = {

--- a/missions/ME_Kazan_Tatarstan_Missions.txt
+++ b/missions/ME_Kazan_Tatarstan_Missions.txt
@@ -2645,11 +2645,7 @@ TRN_missions_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes }}
 				AND = {
 					NOT = { has_building = barracks }
 					NOT = { has_building = training_fields }
@@ -2670,10 +2666,9 @@ TRN_missions_1 = {
 				33 = {
 					owned_by = ROOT
 					is_core = ROOT
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 					OR = {
 						has_building = barracks
@@ -2696,10 +2691,9 @@ TRN_missions_1 = {
 				454 = {
 					owned_by = ROOT
 					is_core = ROOT
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 					OR = {
 						has_building = barracks

--- a/missions/ME_Khmer_Missions.txt
+++ b/missions/ME_Khmer_Missions.txt
@@ -444,23 +444,16 @@ KHM_missions_4 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 18 }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			609 = {
 				owned_by = ROOT
 				development = 18
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Khmer_Missions.txt
+++ b/missions/ME_Khmer_Missions.txt
@@ -18,9 +18,7 @@ KHM_missions_1 = {
 				NOT = { development = 12 }
 				AND = {
 					province_id = 606
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
-				}
+					NOT = { province_has_building_of_group = { group = production all = yes } }				}
 			}
 		}
 		trigger = {
@@ -30,9 +28,9 @@ KHM_missions_1 = {
 				development = 12
 			}
 			606 = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}
@@ -480,18 +478,15 @@ KHM_missions_4 = {
 			province_id = 609
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
 			609 = {
 				owned_by = ROOT
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			treasury = 500

--- a/missions/ME_Khorasan_Missions.txt
+++ b/missions/ME_Khorasan_Missions.txt
@@ -253,10 +253,10 @@ Khorasan_missions_slot_3 = {
 		}
 		trigger = {
 			calc_true_if = {
-				all_province = {
-					OR = {
-						has_building = temple
-						has_building = cathedral
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Kilwa_Missions.txt
+++ b/missions/ME_Kilwa_Missions.txt
@@ -113,12 +113,7 @@ ZAN_missions_1 = {
 			province_id = 1196
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { development = 19 }
 			}
 		}
@@ -126,11 +121,9 @@ ZAN_missions_1 = {
 			is_at_war = no
 			owns = 1196
 			1196 = {
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				development = 19
 			}

--- a/missions/ME_Knights_Missions.txt
+++ b/missions/ME_Knights_Missions.txt
@@ -95,18 +95,15 @@ KNI_slot_1 = {
 			province_id = 320
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 			}
 		}
 		trigger = {
 			owns = 320
 			320 = {
-				OR = {
-					has_building = shipyard
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 			}
 		}
@@ -887,9 +884,9 @@ KNI_slot_5 = {
 			navy_size_percentage = 0.8
 			num_of_owned_provinces_with = {
 				value = 5
-				OR = {
-					has_building = shipyard
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 			}
 		}

--- a/missions/ME_Knights_Missions.txt
+++ b/missions/ME_Knights_Missions.txt
@@ -46,10 +46,7 @@ KNI_slot_1 = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 15 }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
@@ -60,9 +57,9 @@ KNI_slot_1 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 					province_has_building_of_group = { group = trade all = yes }
 				}
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Knights_Missions.txt
+++ b/missions/ME_Knights_Missions.txt
@@ -45,11 +45,7 @@ KNI_slot_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 15 }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				AND = {
 					NOT = { has_building = temple }
 					NOT = { has_building = cathedral }
@@ -60,10 +56,9 @@ KNI_slot_1 = {
 			owns = 320
 			320 = {
 				development = 15
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				OR = {
 					has_building = temple
@@ -790,11 +785,7 @@ KNI_slot_4 = {
 					}
 					OR = {
 						NOT = { owned_by = ROOT }
-						AND = {
-							NOT = { has_building = marketplace }
-							NOT = { has_building = trade_depot }
-							NOT = { has_building = stock_exchange }
-						}
+						NOT = { province_has_building_of_group = { group = trade all = yes } }
 					}
 				}
 			}
@@ -813,24 +804,21 @@ KNI_slot_4 = {
 				owned_by = ROOT
 			}
 			377 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			378 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			382 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Knights_Missions.txt
+++ b/missions/ME_Knights_Missions.txt
@@ -180,19 +180,19 @@ KNI_slot_2 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				AND = {
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+						province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
+					}
 				}
 			}
 		}
 		trigger = {
 			320 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+					province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 				}
 			}
 		}
@@ -725,23 +725,16 @@ KNI_slot_4 = {
 			province_id = 379
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 				religion_group = muslim
 			}
 		}
 		trigger = {
 			owns = 379
 			379 = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				NOT = { religion_group = muslim }
 			}

--- a/missions/ME_Kongo_Missions.txt
+++ b/missions/ME_Kongo_Missions.txt
@@ -1196,21 +1196,16 @@ KON_missions_3 = {
 			area = coastal_kongo
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = navyforcelimit_lvl_2 }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 			}
 		}
 		trigger = {
 			coastal_kongo = {
 				type = all
 				owned_by = ROOT
-				OR = {
-					has_building = shipyard
-					has_building = navyforcelimit_lvl_2
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 			}
 		}

--- a/missions/ME_Kongo_Missions.txt
+++ b/missions/ME_Kongo_Missions.txt
@@ -1126,31 +1126,22 @@ KON_missions_3 = {
 			}
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			1169 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			798 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Korea_Missions.txt
+++ b/missions/ME_Korea_Missions.txt
@@ -1093,11 +1093,7 @@ KOR_missions_3 = {
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				NOT = { development = 35 }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				AND = {
 					NOT = { has_building = temple }
 					NOT = { has_building = cathedral }
@@ -1113,10 +1109,9 @@ KOR_missions_3 = {
 			735 = {
 				country_or_non_sovereign_subject_holds = ROOT
 				development = 35
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				OR = {
 					has_building = temple
@@ -1366,22 +1361,15 @@ KOR_missions_4 = {
 		provinces_to_highlight = {
 			province_id = 735
 			OR = {
-				NOT = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
-					}
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 			}
 		}
 		trigger = {
 			735 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}
@@ -1858,22 +1846,15 @@ KOR_missions_5 = {
 		provinces_to_highlight = {
 			province_id = 2745
 			OR = {
-				NOT = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
-					}
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 			}
 		}
 		trigger = {
 			2745 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}
@@ -1922,11 +1903,7 @@ KOR_missions_5 = {
 			province_id = 4637
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				AND = {
 					NOT = { has_building = temple }
 					NOT = { has_building = cathedral }
@@ -1940,10 +1917,9 @@ KOR_missions_5 = {
 		trigger = {
 			4637 = {
 				owned_by = ROOT
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				OR = {
 					has_building = temple

--- a/missions/ME_Korea_Missions.txt
+++ b/missions/ME_Korea_Missions.txt
@@ -1092,10 +1092,7 @@ KOR_missions_3 = {
 				NOT = { development = 35 }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 				NOT = { has_building = town_hall }
 			}
 		}
@@ -1111,9 +1108,9 @@ KOR_missions_3 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				has_building = town_hall
 			}
@@ -1899,10 +1896,7 @@ KOR_missions_5 = {
 				NOT = { owned_by = ROOT }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
@@ -1916,9 +1910,9 @@ KOR_missions_5 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}

--- a/missions/ME_Korea_Missions.txt
+++ b/missions/ME_Korea_Missions.txt
@@ -828,18 +828,15 @@ KOR_missions_3 = {
 		provinces_to_highlight = {
 			province_id = 735
 			OR = {
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 			}
 		}
 		trigger = {
 			735 = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}
@@ -1094,10 +1091,7 @@ KOR_missions_3 = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				NOT = { development = 35 }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				AND = {
 					NOT = { has_building = workshop }
 					NOT = { has_building = counting_house }
@@ -1113,9 +1107,9 @@ KOR_missions_3 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 					province_has_building_of_group = { group = trade all = yes }
 				}
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				OR = {
 					has_building = workshop
@@ -1904,10 +1898,7 @@ KOR_missions_5 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				AND = {
 					NOT = { has_building = workshop }
 					NOT = { has_building = counting_house }
@@ -1921,9 +1912,9 @@ KOR_missions_5 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 					province_has_building_of_group = { group = trade all = yes }
 				}
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				OR = {
 					has_building = workshop

--- a/missions/ME_Korea_Missions.txt
+++ b/missions/ME_Korea_Missions.txt
@@ -1093,7 +1093,7 @@ KOR_missions_3 = {
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { province_has_building_of_group = { group = production all = yes } }
-				NOT = { has_building = town_hall }
+				NOT = { province_has_building_of_group = { group = government equal_or_more_advanced_than = town_hall } }
 			}
 		}
 		trigger = {
@@ -1112,7 +1112,10 @@ KOR_missions_3 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
 					province_has_building_of_group = { group = production all = yes }
 				}
-				has_building = town_hall
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_EOMAT_town_hall
+					province_has_building_of_group = { group = government equal_or_more_advanced_than = town_hall }
+				}
 			}
 		}
 		effect = {

--- a/missions/ME_Korea_Missions.txt
+++ b/missions/ME_Korea_Missions.txt
@@ -209,10 +209,9 @@ KOR_missions_1 = {
 			province_id = 735 
 			OR = {
 				NOT = {
-					OR = {
-						has_building = fort_16th
-						has_building = fort_17th
-						has_building = fort_18th
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+						province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 					}
 				}
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
@@ -220,10 +219,9 @@ KOR_missions_1 = {
 		}
 		trigger = {
 			735 = {
-				OR = {
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+					province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 				}
 				country_or_non_sovereign_subject_holds = ROOT
 			}

--- a/missions/ME_Kurdistan_Missions.txt
+++ b/missions/ME_Kurdistan_Missions.txt
@@ -678,22 +678,17 @@ Generic_Kurdistan_5 = {
 		position = 3
 		provinces_to_highlight = {
 			owned_by = ROOT
-			NOT = {
-				OR = {
-					has_building = marketplace
-					has_building = stock_exchange
-					has_building = trade_depot
-				}
-			}		
+			NOT = { province_has_building_of_group = { group = trade all = yes } }	
 		}
 		trigger = {
-			num_of_owned_provinces_with = {
-				OR = {
-					has_building = marketplace
-					has_building = stock_exchange
-					has_building = trade_depot
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
 				}
-				value = 3
+				amount = 3
 			}
 		}
 		effect = {

--- a/missions/ME_Kurdistan_Missions.txt
+++ b/missions/ME_Kurdistan_Missions.txt
@@ -708,20 +708,17 @@ Generic_Kurdistan_5 = {
 		position = 5
 		provinces_to_highlight = {
 			owned_by = ROOT
-			NOT = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
-				}
-			}		
+			NOT = { province_has_building_of_group = { group = production all = yes } }
 		}
 		trigger = {
-			num_of_owned_provinces_with = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
+					}
 				}
-				value = 5
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Kurland_Missions.txt
+++ b/missions/ME_Kurland_Missions.txt
@@ -1150,14 +1150,17 @@ kurland_missions_5 = {
 			province_id = 39
 			OR = {
 				NOT = { owned_by = ROOT }
-				NOT = { has_building = grand_shipyard }
+				NOT = {province_has_building_of_group = { group = navy equal_or_more_advanced_than = grand_shipyard } }
 				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = drydock } }
 			}
 		}
 		trigger = {
 			39 = {
 				owned_by = ROOT
-				has_building = grand_shipyard
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = grand_shipyard }
+					}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_drydock
 						province_has_building_of_group = { group = navy equal_or_more_advanced_than = drydock }

--- a/missions/ME_Kurland_Missions.txt
+++ b/missions/ME_Kurland_Missions.txt
@@ -1151,14 +1151,17 @@ kurland_missions_5 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { has_building = grand_shipyard }
-				NOT = { has_building = drydock }
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = drydock } }
 			}
 		}
 		trigger = {
 			39 = {
 				owned_by = ROOT
 				has_building = grand_shipyard
-				has_building = drydock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_drydock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = drydock }
+					}
 			}
 		}
 		effect = {

--- a/missions/ME_Livonian_Order_Missions.txt
+++ b/missions/ME_Livonian_Order_Missions.txt
@@ -50,9 +50,14 @@ LIV_missions_1 = {
 		trigger = {
 			army_size_percentage = 1
 			num_of_generals = 2
-			OR = {
-				barracks = 2
-				training_fields = 2
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
+					}
+				}
+				amount = 2
 			}
 		}
 		effect = {

--- a/missions/ME_Lorraine_Missions.txt
+++ b/missions/ME_Lorraine_Missions.txt
@@ -54,49 +54,36 @@ LOR_missions_2 = {
 			}
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			4383 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			1744 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			93 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			99 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Lorraine_Missions.txt
+++ b/missions/ME_Lorraine_Missions.txt
@@ -476,11 +476,7 @@ LOR_missions_4 = {
 					NOT = { has_dlc = "Dharma" }
 					OR = {
 						NOT = { development = 20 }
-						AND = {
-							NOT = { has_building = marketplace }
-							NOT = { has_building = trade_depot }
-							NOT = { has_building = stock_exchange }
-						}
+						NOT = { province_has_building_of_group = { group = trade all = yes } }
 					}
 				}
 			}
@@ -506,26 +502,23 @@ LOR_missions_4 = {
 			else = {
 				78 = {
 					development = 20
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				85 = {
 					development = 20
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				188 = {
 					development = 20
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 			}

--- a/missions/ME_Lubeck_Hansa_Missions.txt
+++ b/missions/ME_Lubeck_Hansa_Missions.txt
@@ -518,7 +518,7 @@ HSA_HNS_missions_3 = {
 		provinces_to_highlight = {
 			is_capital_of = ROOT
 			OR = {
-				NOT = { has_building = courthouse }
+				NOT = { province_has_building_of_group = { group = government all = yes } }
 				NOT = { development = 25 }
 			}
 		}

--- a/missions/ME_Lubeck_Hansa_Missions.txt
+++ b/missions/ME_Lubeck_Hansa_Missions.txt
@@ -593,12 +593,7 @@ HSA_HNS_missions_4 = {
 			province_id = 45
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 				NOT = { base_manpower = 6 }
 			}
 		}
@@ -607,11 +602,9 @@ HSA_HNS_missions_4 = {
 			treasury = 500
 			45 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				base_manpower = 6
 			}

--- a/missions/ME_Lucca_Missions.txt
+++ b/missions/ME_Lucca_Missions.txt
@@ -1314,9 +1314,9 @@ lucca_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Lucca_Missions.txt
+++ b/missions/ME_Lucca_Missions.txt
@@ -634,12 +634,12 @@ lucca_missions_slot_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = temple
-						has_building = cathedral
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 				}
-				amount = 10
+				amount = 20
 			}
 		}
 		effect = {

--- a/missions/ME_Lucca_Missions.txt
+++ b/missions/ME_Lucca_Missions.txt
@@ -1338,10 +1338,9 @@ lucca_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Lucca_Missions.txt
+++ b/missions/ME_Lucca_Missions.txt
@@ -659,8 +659,10 @@ lucca_missions_slot_3 = {
 			calc_true_if = {
 				all_owned_province = {
 					OR = {
-						has_building = courthouse
-						has_building = town_hall
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+							province_has_building_of_group = { group = government all = yes }
+						}
 						has_building = university
 					}
 				}

--- a/missions/ME_Lucca_Missions.txt
+++ b/missions/ME_Lucca_Missions.txt
@@ -1247,11 +1247,9 @@ lucca_missions_slot_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Lucca_Missions.txt
+++ b/missions/ME_Lucca_Missions.txt
@@ -734,11 +734,9 @@ lucca_missions_slot_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = dock
-						has_building = drydock
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+						province_has_building_of_group = { group = navy all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Luristan_Missions.txt
+++ b/missions/ME_Luristan_Missions.txt
@@ -491,14 +491,14 @@ lur_slot_4 = {
 		required_missions = { LRI_economics_of_the_state }
 		position = 3
 		trigger = {
-			num_of_owned_provinces_with = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
-					has_building = workshop
-					has_building = counting_house
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
-				value = 3
+				amount = 3
 			}
 		}
 		effect = {

--- a/missions/ME_Luristan_Missions.txt
+++ b/missions/ME_Luristan_Missions.txt
@@ -553,23 +553,18 @@ lur_slot_5 = {
 		position = 3
 		trigger = {
 			any_owned_province = {
-				OR = {
-					has_building = marketplace
-					has_building = stock_exchange
-					has_building = trade_depot
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
-			}	
+			}
 		}
 		effect = {
 			if = {
 				limit = {
 					NOT = {
 						any_owned_province = {
-							OR = {
-								has_building = marketplace
-								has_building = stock_exchange
-								has_building = trade_depot
-							}
+							province_has_building_of_group = { group = trade all = yes }
 						}
 					}
 				}
@@ -586,11 +581,8 @@ lur_slot_5 = {
 			}
 			random_owned_province = {
 				limit = {
-					OR = {
-						has_building = marketplace
-						has_building = stock_exchange
-						has_building = trade_depot
-					}
+					province_has_building_of_group = { group = trade all = yes }
+
 				}
 				add_trade_modifier = {
 					who = ROOT

--- a/missions/ME_Mainz_Missions.txt
+++ b/missions/ME_Mainz_Missions.txt
@@ -311,11 +311,9 @@ mainz_missions_slot_1 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = dock
-						has_building = drydock
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+						province_has_building_of_group = { group = navy all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Mainz_Missions.txt
+++ b/missions/ME_Mainz_Missions.txt
@@ -38,11 +38,9 @@ mainz_missions_slot_1 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Mainz_Missions.txt
+++ b/missions/ME_Mainz_Missions.txt
@@ -14,9 +14,9 @@ mainz_missions_slot_1 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Mali_Missions.txt
+++ b/missions/ME_Mali_Missions.txt
@@ -687,20 +687,15 @@ MAL_missions_4 = {
 			province_id = 1132
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			1132 = {
 				owned_by = ROOT
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Malta_Carthage_Missions.txt
+++ b/missions/ME_Malta_Carthage_Missions.txt
@@ -77,14 +77,13 @@ JAI_CTH_missions_slot_1 = {
 		required_missions = { jai_expand }
 		provinces_to_highlight = {
 			is_capital_of = ROOT
-			NOT = { has_building = shipyard }
-			NOT = { has_building = grand_shipyard }
+			NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 		}
 		trigger = {
 			capital_scope = {
-				OR = {
-					has_building = shipyard
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 			}
 		}

--- a/missions/ME_Mamluks_Missions.txt
+++ b/missions/ME_Mamluks_Missions.txt
@@ -17,12 +17,7 @@ MAM_missions_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 30 }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = production_lvl_2 }
-					NOT = { has_building = production_lvl_3 }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
@@ -30,11 +25,9 @@ MAM_missions_1 = {
 			owns = 361
 			361 = {
 				development = 30
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
@@ -82,12 +75,7 @@ MAM_missions_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 15 }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = production_lvl_2 }
-					NOT = { has_building = production_lvl_3 }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
@@ -95,11 +83,9 @@ MAM_missions_1 = {
 				type = all
 				owned_by = ROOT
 				development = 15
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			if = {
@@ -1294,12 +1280,7 @@ MAM_missions_4 = {
 				NOT = { development = 25 }
 				devastation = 1
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = production_lvl_2 }
-					NOT = { has_building = production_lvl_3 }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
@@ -1312,11 +1293,9 @@ MAM_missions_4 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3 
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}

--- a/missions/ME_Mamluks_Missions.txt
+++ b/missions/ME_Mamluks_Missions.txt
@@ -23,12 +23,7 @@ MAM_missions_1 = {
 					NOT = { has_building = production_lvl_3 }
 					NOT = { has_building = counting_house }
 				}
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
@@ -41,11 +36,9 @@ MAM_missions_1 = {
 					has_building = production_lvl_3
 					has_building = counting_house
 				}
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -1300,12 +1293,7 @@ MAM_missions_4 = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 25 }
 				devastation = 1
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				AND = {
 					NOT = { has_building = workshop }
 					NOT = { has_building = production_lvl_2 }
@@ -1320,11 +1308,9 @@ MAM_missions_4 = {
 				owned_by = ROOT
 				development = 25
 				NOT = { devastation = 1 }
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				OR = {
 					has_building = workshop

--- a/missions/ME_Manchu_zMissions.txt
+++ b/missions/ME_Manchu_zMissions.txt
@@ -2072,7 +2072,10 @@ manchu_missions_5 = {
 		trigger = {
 			has_idea = the_manchu_alphabet
 			capital_scope = {
-				has_building = courthouse
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+					province_has_building_of_group = { group = government all = yes }
+				}
 				development = 20
 			}
 			has_institution = renaissance 
@@ -2088,7 +2091,15 @@ manchu_missions_5 = {
 		required_missions = { officializing_the_manchu_script }
 		position = 4
 		trigger = {
-			courthouse = 6
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+						province_has_building_of_group = { group = government all = yes }
+					}
+				}
+				amount = 6
+			}
 		}
 		effect = {
 			if = {

--- a/missions/ME_Mann_Missions.txt
+++ b/missions/ME_Mann_Missions.txt
@@ -22,10 +22,7 @@ Mann_missions_1 = {
 				AND = {
 					NOT = { has_dlc = "Common Sense" }
 					OR = {
-						AND = {
-							NOT = { has_building = workshop }
-							NOT = { has_building = counting_house }
-						}
+						NOT = { province_has_building_of_group = { group = production all = yes } }
 						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 					}
 				}
@@ -41,9 +38,9 @@ Mann_missions_1 = {
 					base_tax = 5
 				}
 				else = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 					custom_trigger_tooltip = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL

--- a/missions/ME_Mann_Missions.txt
+++ b/missions/ME_Mann_Missions.txt
@@ -110,10 +110,7 @@ Mann_missions_1 = {
 				AND = {
 					NOT = { has_dlc = "Common Sense" }
 					OR = {
-						AND = {
-							NOT = { has_building = barracks }
-							NOT = { has_building = training_fields }
-						}
+						NOT = { province_has_building_of_group = { group = manpower all = yes } }
 						AND = {
 							NOT = { has_building = regimental_camp }
 							NOT = { has_building = conscription_center }
@@ -132,9 +129,9 @@ Mann_missions_1 = {
 					base_manpower = 5
 				}
 				else = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
 					}
 					OR = {
 						has_building = regimental_camp

--- a/missions/ME_Mann_Missions.txt
+++ b/missions/ME_Mann_Missions.txt
@@ -111,10 +111,7 @@ Mann_missions_1 = {
 					NOT = { has_dlc = "Common Sense" }
 					OR = {
 						NOT = { province_has_building_of_group = { group = manpower all = yes } }
-						AND = {
-							NOT = { has_building = regimental_camp }
-							NOT = { has_building = conscription_center }
-						}
+						NOT = { province_has_building_of_group = { group = forcelimit all = yes } }
 					}
 				}
 			}
@@ -133,9 +130,9 @@ Mann_missions_1 = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
 						province_has_building_of_group = { group = manpower all = yes }
 					}
-					OR = {
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL
+						province_has_building_of_group = { group = forcelimit all = yes }
 					}
 				}
 			}

--- a/missions/ME_Mann_Missions.txt
+++ b/missions/ME_Mann_Missions.txt
@@ -26,10 +26,7 @@ Mann_missions_1 = {
 							NOT = { has_building = workshop }
 							NOT = { has_building = counting_house }
 						}
-						AND = {
-							NOT = { has_building = temple }
-							NOT = { has_building = cathedral }
-						}
+						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 					}
 				}
 			}
@@ -48,9 +45,9 @@ Mann_missions_1 = {
 						has_building = workshop
 						has_building = counting_house
 					}
-					OR = {
-						has_building = temple
-						has_building = cathedral
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 				}
 			}

--- a/missions/ME_Mantua_Missions.txt
+++ b/missions/ME_Mantua_Missions.txt
@@ -328,18 +328,15 @@ man_mission_2 = {
 			province_id = 109
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			109 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Maya_Missions.txt
+++ b/missions/ME_Maya_Missions.txt
@@ -1688,12 +1688,11 @@ maya_missions_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					has_port = yes
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
+					has_port = yes
 				}
 				amount = 10
 			}

--- a/missions/ME_Maya_Missions.txt
+++ b/missions/ME_Maya_Missions.txt
@@ -1285,12 +1285,7 @@ maya_missions_2 = {
 		effect = {
 			every_owned_province = {
 				limit = {
-					OR = {
-						has_building = workshop
-						has_building = production_lvl_2
-						has_building = production_lvl_3
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 				}
 				add_province_modifier = {
 					name = maya_workshops_province_modifier

--- a/missions/ME_Maya_Missions.txt
+++ b/missions/ME_Maya_Missions.txt
@@ -957,35 +957,32 @@ maya_missions_2 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 12 }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			owns = 846
 			846 = {
 				development = 12
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			owns = 2633
 			2633 = {
 				development = 12
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			owns = 4590
 			4590 = {
 				development = 12
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -1029,10 +1026,7 @@ maya_missions_2 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 15 }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
@@ -1040,18 +1034,18 @@ maya_missions_2 = {
 				type = all
 				owned_by = ROOT
 				development = 15
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			east_yucatan_area = {
 				type = all
 				owned_by = ROOT
 				development = 15
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Maya_Missions.txt
+++ b/missions/ME_Maya_Missions.txt
@@ -1528,10 +1528,7 @@ maya_missions_3 = {
 			is_capital_of = ROOT
 			OR = {
 				NOT = { development = 20 }
-				AND = {
-					NOT = { has_building = courthouse }
-					NOT = { has_building = town_hall }
-				}
+				NOT = { province_has_building_of_group = { group = government all = yes } }
 				AND = {
 					NOT = { has_building = fort_15th }
 					NOT = { has_building = fort_16th }
@@ -1543,9 +1540,9 @@ maya_missions_3 = {
 		trigger = {
 			capital_scope = {
 				development = 20
-				OR = {
-					has_building = courthouse
-					has_building = town_hall
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+					province_has_building_of_group = { group = government all = yes }
 				}
 				OR = {
 					has_building = fort_15th
@@ -2443,7 +2440,15 @@ maya_missions_4 = {
 		required_missions = { maya_adapt_european_agriculture maya_long_distance_network maya_mayan_mathematics }
 		position = 11
 		trigger = {
-			town_hall = 15
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_EOMAT_town_hall
+						province_has_building_of_group = { group = government equal_or_more_advanced_than = town_hall }
+					}
+				}
+				amount = 15
+			}
 		}
 		effect = {
 			add_absolutism = 20

--- a/missions/ME_Maya_Missions.txt
+++ b/missions/ME_Maya_Missions.txt
@@ -1529,12 +1529,7 @@ maya_missions_3 = {
 			OR = {
 				NOT = { development = 20 }
 				NOT = { province_has_building_of_group = { group = government all = yes } }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
@@ -1544,11 +1539,9 @@ maya_missions_3 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
 					province_has_building_of_group = { group = government all = yes }
 				}
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Mazovia_Missions.txt
+++ b/missions/ME_Mazovia_Missions.txt
@@ -24,8 +24,7 @@ MAZ_missions_1 = {
 				}
 				AND = {
 					NOT = { has_dlc = "Common Sense" }
-					NOT = { has_building = courthouse }
-					NOT = { has_building = town_hall }
+					NOT = { province_has_building_of_group = { group = government all = yes } }
 				}
 			}
 		}
@@ -45,15 +44,15 @@ MAZ_missions_1 = {
 			}
 			else = {
 				256 = {
-					OR = {
-						has_building = courthouse
-						has_building = town_hall
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+						province_has_building_of_group = { group = government all = yes }
 					}
 				}
 				1938 = {
-					OR = {
-						has_building = courthouse
-						has_building = town_hall
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+						province_has_building_of_group = { group = government all = yes }
 					}
 				}
 			}

--- a/missions/ME_Ming_Missions.txt
+++ b/missions/ME_Ming_Missions.txt
@@ -133,52 +133,39 @@ MNG_missions_1_4 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				devastation = 0.01
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			4223 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				NOT = { devastation = 0.01 }
 			}
 			702 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				NOT = { devastation = 0.01 }
 			}
 			2136 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				NOT = { devastation = 0.01 }
 			}
 			2112 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 				NOT = { devastation = 0.01 }
 			}
@@ -186,11 +173,9 @@ MNG_missions_1_4 = {
 		effect = {
 			every_owned_province = {
 				limit = {
-					OR = {
-						has_building = fort_15th
-						has_building = fort_16th
-						has_building = fort_17th
-						has_building = fort_18th
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+						province_has_building_of_group = { group = defense all = yes }
 					}
 					NOT = { devastation = 0.01 }
 				}

--- a/missions/ME_Ming_Missions.txt
+++ b/missions/ME_Ming_Missions.txt
@@ -263,12 +263,7 @@ MNG_missions_1_4 = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 35 }
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
-				AND = {
-					NOT = { has_building = dock }
-					NOT = { has_building = drydock }
-					NOT = { has_building = shipyard }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy all = yes } }
 				variable_arithmetic_trigger = {
 					export_to_variable = {
 						which = nanjing_development
@@ -292,11 +287,9 @@ MNG_missions_1_4 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
-				OR = {
-					has_building = dock
-					has_building = drydock
-					has_building = shipyard
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+					province_has_building_of_group = { group = navy all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_Ming_Missions.txt
+++ b/missions/ME_Ming_Missions.txt
@@ -262,10 +262,7 @@ MNG_missions_1_4 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 35 }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				AND = {
 					NOT = { has_building = dock }
 					NOT = { has_building = drydock }
@@ -291,9 +288,9 @@ MNG_missions_1_4 = {
 			1816 = {
 				owned_by = ROOT
 				development = 35
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				OR = {
 					has_building = dock

--- a/missions/ME_Ming_Missions.txt
+++ b/missions/ME_Ming_Missions.txt
@@ -301,10 +301,9 @@ MNG_missions_1_4 = {
 					has_building = shipyard
 					has_building = grand_shipyard
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			variable_arithmetic_trigger = {

--- a/missions/ME_Modena_Missions.txt
+++ b/missions/ME_Modena_Missions.txt
@@ -364,10 +364,7 @@ modenese_mission_group_4 = {
 					NOT = { has_building = workshop }
 					NOT = { has_building = counting_house }
 				}
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		position = 2
@@ -378,9 +375,9 @@ modenese_mission_group_4 = {
 					has_building = workshop
 					has_building = counting_house
 				}
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -420,14 +417,17 @@ modenese_mission_group_4 = {
 			province_id = 106
 			OR = {
 				NOT = { owned_by = ROOT }
-				NOT = { has_building = cathedral }
+				NOT = { province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral } }
 			}
 		}
 		position = 4
 		trigger = {
 			106 = {
 				owned_by = ROOT
-				has_building = cathedral
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
+						province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral }
+					}
 			}
 		}
 		effect = {

--- a/missions/ME_Modena_Missions.txt
+++ b/missions/ME_Modena_Missions.txt
@@ -360,10 +360,7 @@ modenese_mission_group_4 = {
 			province_id = 106
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
@@ -371,9 +368,9 @@ modenese_mission_group_4 = {
 		trigger = {
 			106 = {
 				owned_by = ROOT
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL

--- a/missions/ME_Montferrat_Missions.txt
+++ b/missions/ME_Montferrat_Missions.txt
@@ -607,9 +607,9 @@ montferrat_missions_slot_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Montferrat_Missions.txt
+++ b/missions/ME_Montferrat_Missions.txt
@@ -768,8 +768,10 @@ montferrat_missions_slot_5 = {
 			calc_true_if = {
 				all_owned_province = {
 					OR = {
-						has_building = courthouse
-						has_building = town_hall
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+							province_has_building_of_group = { group = government all = yes }
+						}
 						has_building = university
 					}
 				}

--- a/missions/ME_Montferrat_Missions.txt
+++ b/missions/ME_Montferrat_Missions.txt
@@ -792,11 +792,9 @@ montferrat_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Montferrat_Missions.txt
+++ b/missions/ME_Montferrat_Missions.txt
@@ -583,10 +583,9 @@ montferrat_missions_slot_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Montferrat_Missions.txt
+++ b/missions/ME_Montferrat_Missions.txt
@@ -741,11 +741,9 @@ montferrat_missions_slot_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = dock
-						has_building = drydock
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+						province_has_building_of_group = { group = navy all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Moravia_Missions.txt
+++ b/missions/ME_Moravia_Missions.txt
@@ -644,20 +644,20 @@ MVA_missions_5 = {
 			province_id = 265
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
+				NOT = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+						province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
+					}
 				}
 			}
 		}
 		trigger = {
 			265 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+					province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 				}
 			}
 		}

--- a/missions/ME_Moravia_Missions.txt
+++ b/missions/ME_Moravia_Missions.txt
@@ -576,22 +576,15 @@ MVA_missions_5 = {
 			province_id = 265
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			265 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Netherlands_Holland_Missions.txt
+++ b/missions/ME_Netherlands_Holland_Missions.txt
@@ -123,10 +123,14 @@ NED_HOL_missions_1 = {
 		required_missions = { netherlands_holland_amsterdam_port }
 		position = 7
 		trigger = {
-			OR = {
-				marketplace = 5
-				trade_depot = 5
-				stock_exchange = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 5
 			}
 			estate_loyalty = {
 				estate = estate_burghers
@@ -636,12 +640,7 @@ NED_HOL_missions_2 = {
 				NOT = { owned_by = ROOT }
 				is_state = no
 				NOT = { development = 22 }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				AND = {
 					has_dlc = "Mandate of Heaven"
 					is_prosperous = no
@@ -661,11 +660,9 @@ NED_HOL_missions_2 = {
 				owned_by = ROOT
 				is_state = yes
 				development = 22
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				if = {
 					limit = {

--- a/missions/ME_Netherlands_Holland_Missions.txt
+++ b/missions/ME_Netherlands_Holland_Missions.txt
@@ -716,23 +716,16 @@ NED_HOL_missions_2 = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
 				NOT = { development = 25 }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = production_lvl_2 }
-					NOT = { has_building = production_lvl_3 }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
 			owns_core_province = 1744
 			1744 = {
 				development = 25
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}

--- a/missions/ME_Netherlands_Holland_Missions.txt
+++ b/missions/ME_Netherlands_Holland_Missions.txt
@@ -340,9 +340,14 @@ NED_HOL_missions_2 = {
 		trigger = {
 			is_year = 1470
 			advisor = naval_reformer
-			OR = {
-				shipyard = 5
-				grand_shipyard = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
+					}
+				}
+				amount = 5
 			}
 			num_of_heavy_ship = 10
 		}

--- a/missions/ME_Nitra_Missions.txt
+++ b/missions/ME_Nitra_Missions.txt
@@ -704,10 +704,7 @@ SLO_missions_5 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 			    NOT = { development = 30 }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
@@ -715,9 +712,9 @@ SLO_missions_5 = {
 		    1772 = {
 				owned_by = ROOT
 			    development = 30
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL

--- a/missions/ME_Nitra_Missions.txt
+++ b/missions/ME_Nitra_Missions.txt
@@ -708,10 +708,7 @@ SLO_missions_5 = {
 					NOT = { has_building = workshop }
 					NOT = { has_building = counting_house }
 				}
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
@@ -722,9 +719,9 @@ SLO_missions_5 = {
 					has_building = workshop
 					has_building = counting_house
 				}
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Nitra_Missions.txt
+++ b/missions/ME_Nitra_Missions.txt
@@ -624,22 +624,15 @@ SLO_missions_5 = {
 			province_id = 1772
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			1772 = {
 				country_or_non_sovereign_subject_holds = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Northumberland_Missions.txt
+++ b/missions/ME_Northumberland_Missions.txt
@@ -412,11 +412,9 @@ northumberland_missions_5 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = dock
-						has_building = drydock
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+						province_has_building_of_group = { group = navy all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Northumberland_Missions.txt
+++ b/missions/ME_Northumberland_Missions.txt
@@ -356,9 +356,9 @@ northumberland_missions_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Northumberland_Missions.txt
+++ b/missions/ME_Northumberland_Missions.txt
@@ -380,10 +380,9 @@ northumberland_missions_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Northumberland_Missions.txt
+++ b/missions/ME_Northumberland_Missions.txt
@@ -269,11 +269,9 @@ northumberland_missions_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Norway_Missions.txt
+++ b/missions/ME_Norway_Missions.txt
@@ -98,8 +98,7 @@ NOR_mission_group_1 = {
 				}
 				AND = {
 					NOT = { has_dlc = "Common Sense" }
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
+					NOT = { province_has_building_of_group = { group = production all = yes } }
 				}
 			}
 		}
@@ -116,9 +115,9 @@ NOR_mission_group_1 = {
 					development = 13
 				}
 				else = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 			}

--- a/missions/ME_Novgorod_Missions.txt
+++ b/missions/ME_Novgorod_Missions.txt
@@ -17,11 +17,9 @@ NOV_missions_1 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_lvl_2
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				amount = 5
@@ -117,11 +115,14 @@ NOV_missions_1 = {
 						has_building = taxation_lvl_4
 						has_building = university
 						has_building = counting_house
-						has_building = farm_estate
-						has_building = tradecompany
-						has_building = stock_exchange
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_stock_exchange
+							province_has_building_of_group = { group = trade equal_or_more_advanced_than = stock_exchange }
+						}
 						has_building = weapons
 						has_building = wharf
+						has_building = farm_estate
+						has_building = tradecompany
 					}
 				}
 				amount = 35

--- a/missions/ME_Novgorod_Missions.txt
+++ b/missions/ME_Novgorod_Missions.txt
@@ -195,10 +195,10 @@ NOV_missions_2 = {
 			calc_true_if = {
 				all_owned_province = {
 					OR = {
-						has_building = fort_15th
-						has_building = fort_16th
-						has_building = fort_17th
-						has_building = fort_18th
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+							province_has_building_of_group = { group = defense all = yes }
+						}
 						custom_trigger_tooltip = {
 							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
 							province_has_building_of_group = { group = manpower all = yes }

--- a/missions/ME_Novgorod_Missions.txt
+++ b/missions/ME_Novgorod_Missions.txt
@@ -199,9 +199,10 @@ NOV_missions_2 = {
 						has_building = fort_16th
 						has_building = fort_17th
 						has_building = fort_18th
-						has_building = manpower_lvl_1
-						has_building = barracks
-						has_building = training_fields
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+							province_has_building_of_group = { group = manpower all = yes }
+						}
 					}
 				}
 				amount = 5

--- a/missions/ME_Novgorod_Missions.txt
+++ b/missions/ME_Novgorod_Missions.txt
@@ -114,7 +114,10 @@ NOV_missions_1 = {
 					OR = {
 						has_building = taxation_lvl_4
 						has_building = university
-						has_building = counting_house
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_EOMAT_counting_house
+							province_has_building_of_group = { group = production equal_or_more_advanced_than = counting_house }
+						}
 						custom_trigger_tooltip = {
 							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_stock_exchange
 							province_has_building_of_group = { group = trade equal_or_more_advanced_than = stock_exchange }

--- a/missions/ME_Nuremberg_Missions.txt
+++ b/missions/ME_Nuremberg_Missions.txt
@@ -190,8 +190,7 @@ NUM_missions_5 = {
 				}
 				AND = {
 					NOT = { has_dlc = "Mandate of Heaven" }
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
+					NOT = { province_has_building_of_group = { group = production all = yes } }
 				}
 			}
 		}
@@ -213,9 +212,9 @@ NUM_missions_5 = {
 			}
 			else = {
 				67 = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 			}

--- a/missions/ME_Oda_missions.txt
+++ b/missions/ME_Oda_missions.txt
@@ -273,22 +273,15 @@ ODA_missions_2 = {
 			province_id = 1030
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			owns = 1030
 			1030 = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Otomo_missions.txt
+++ b/missions/ME_Otomo_missions.txt
@@ -333,7 +333,10 @@ ME_OTM_missions_5 = {
 		trigger = {
 			1014 = {
 				development = 15
-				has_building = dock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+				}
 			}
 		}
 		effect = {

--- a/missions/ME_Ottomans_Missions.txt
+++ b/missions/ME_Ottomans_Missions.txt
@@ -2650,9 +2650,9 @@ Ottoman_Missions_4_contd = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
 					province_has_building_of_group = { group = manpower all = yes }
 				}
-				OR = {
-					has_building = regimental_camp
-					has_building = conscription_center
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				fort_level = 1
 			}
@@ -3605,13 +3605,15 @@ Ottoman_Missions_5_Mamluks = {
 		position = 20
 		provinces_to_highlight = { }
 		trigger = {
-			num_of_owned_provinces_with = {
-				is_core = MAM
-				OR = {
-					has_building = regimental_camp
-					has_building = conscription_center
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL
+						province_has_building_of_group = { group = forcelimit all = yes }
+					}
+					is_core = MAM
 				}
-				value = 15
+				amount = 15
 			}
 			custom_trigger_tooltip = {
 				tooltip = TUR_cooldown

--- a/missions/ME_Ottomans_Missions.txt
+++ b/missions/ME_Ottomans_Missions.txt
@@ -756,9 +756,9 @@ Ottoman_Missions_1 = {
 				full_idea_group = innovativeness_ideas
 				1846 = {
 					development = 15
-					OR = {
-						has_building = workshop
-						has_building = courthouse
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 			}

--- a/missions/ME_Ottomans_Missions.txt
+++ b/missions/ME_Ottomans_Missions.txt
@@ -724,7 +724,10 @@ Ottoman_Missions_1 = {
 				capital_scope = {
 					AND = {
 						province_has_center_of_trade_of_level = 2
-						has_building = marketplace
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+							province_has_building_of_group = { group = trade all = yes }
+						}
 					}
 				}
 				AND = {

--- a/missions/ME_Ottomans_Missions.txt
+++ b/missions/ME_Ottomans_Missions.txt
@@ -1280,7 +1280,15 @@ Ottoman_Missions_2 = {
 		position = 17
 		trigger = {
 			university = 15
-			temple = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
+				}
+				amount = 5
+			}
 			IF = {
 				limit = { has_dlc = "Rule Britannia"}
 				innovativeness = 25
@@ -2610,7 +2618,10 @@ Ottoman_Missions_4_contd = {
 			num_of_owned_provinces_with = {
 				value = 15
 				NOT = { religion_group = muslim }
-				has_building = temple
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
+				}
 			}
 			if = {
 				limit = {

--- a/missions/ME_Ottomans_Missions.txt
+++ b/missions/ME_Ottomans_Missions.txt
@@ -2584,9 +2584,9 @@ Ottoman_Missions_4_contd = {
 			num_of_owned_provinces_with = {
 				value = 10
 				NOT = { religion_group = muslim }
-				OR = {
-					has_building = barracks
-					has_building = regimental_camp
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+					province_has_building_of_group = { group = manpower all = yes }
 				}
 				base_manpower = 5
 			}
@@ -2646,9 +2646,9 @@ Ottoman_Missions_4_contd = {
 			num_of_owned_provinces_with = {
 				value = 5
 				development = 30
-				OR = {
-					has_building = barracks
-					has_building = training_fields
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+					province_has_building_of_group = { group = manpower all = yes }
 				}
 				OR = {
 					has_building = regimental_camp
@@ -3502,13 +3502,15 @@ Ottoman_Missions_4_Mamluks = {
 		position = 19
 		provinces_to_highlight = { }
 		trigger = {
-			num_of_owned_provinces_with = {
-				is_core = MAM
-				OR = {
-					has_building = barracks
-					has_building = training_fields
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_MANPOWER_ALL
+						province_has_building_of_group = { group = manpower all = yes }
+					}
+					is_core = MAM
 				}
-				value = 10
+				amount = 10
 			}
 			custom_trigger_tooltip = {
 				tooltip = TUR_cooldown

--- a/missions/ME_Ottomans_Missions.txt
+++ b/missions/ME_Ottomans_Missions.txt
@@ -3544,10 +3544,9 @@ Ottoman_Missions_4_Mamluks = {
 		trigger = {
 			num_of_owned_provinces_with = {
 				is_core = MAM
-				OR = {
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_EOMAT_fort_16th
+					province_has_building_of_group = { group = defense equal_or_more_advanced_than = fort_16th }
 				}
 				value = 3
 			}

--- a/missions/ME_Papal_State_Missions.txt
+++ b/missions/ME_Papal_State_Missions.txt
@@ -22,12 +22,7 @@ PAP_missions_1 = {
 					province_id = 113
 					OR = {
 						NOT = { country_or_non_sovereign_subject_holds = ROOT }
-						AND = {
-							NOT = { has_building = temple }
-							NOT = { has_building = taxation_lvl_2 }
-							NOT = { has_building = cathedral }
-							NOT = { has_building = taxation_lvl_4 }
-						}
+						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 					}
 				}
 			}
@@ -39,11 +34,9 @@ PAP_missions_1 = {
 			}
 			113 = {
 				country_or_non_sovereign_subject_holds = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -955,12 +948,7 @@ PAP_missions_5 = {
 			province_id = 118
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				NOT = { development = 30 }
 			}
@@ -969,11 +957,9 @@ PAP_missions_5 = {
 			treasury = 150
 			118 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_Papal_State_Missions.txt
+++ b/missions/ME_Papal_State_Missions.txt
@@ -800,22 +800,15 @@ PAP_missions_4 = {
 			province_id = 117
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = production_lvl_2 }
-					NOT = { has_building = production_lvl_3 }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
 			117 = {
 				country_or_non_sovereign_subject_holds = ROOT
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}

--- a/missions/ME_Papal_State_Missions.txt
+++ b/missions/ME_Papal_State_Missions.txt
@@ -961,12 +961,7 @@ PAP_missions_5 = {
 					NOT = { has_building = cathedral }
 					NOT = { has_building = taxation_lvl_4 }
 				}
-				AND = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 				NOT = { development = 30 }
 			}
 		}
@@ -980,11 +975,9 @@ PAP_missions_5 = {
 					has_building = cathedral
 					has_building = taxation_lvl_4
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				development = 30
 			}

--- a/missions/ME_Parma_Missions.txt
+++ b/missions/ME_Parma_Missions.txt
@@ -254,18 +254,15 @@ parma_missions_4 = {
 			province_id = 105
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			105 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -287,13 +284,16 @@ parma_missions_4 = {
 			province_id = 105
 			OR = {
 				NOT = { owned_by = ROOT }
-				NOT = { has_building = cathedral }
+				NOT = { province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral } }
 			}
 		}
 		trigger = {
 			105 = {
 				owned_by = ROOT
-				has_building = cathedral
+				custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
+						province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral }
+				}
 			}
 		}
 		effect = {

--- a/missions/ME_Perm_Missions.txt
+++ b/missions/ME_Perm_Missions.txt
@@ -742,12 +742,14 @@ perm_missions_5 = {
 		required_missions = { perm_build_trade_buildings }
 		position = 5
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Perm_Missions.txt
+++ b/missions/ME_Perm_Missions.txt
@@ -284,14 +284,14 @@ perm_missions_2 = {
 		required_missions = { perm_army }
 		position = 7
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = barracks
-					has_building = training_fields
-					has_building = regimental_camp
-					has_building = conscription_center
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Perm_Missions.txt
+++ b/missions/ME_Perm_Missions.txt
@@ -694,12 +694,14 @@ perm_missions_5 = {
 		required_missions = { }
 		position = 3
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = temple
-					has_building = cathedral
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Perm_Missions.txt
+++ b/missions/ME_Perm_Missions.txt
@@ -716,13 +716,14 @@ perm_missions_5 = {
 		required_missions = { perm_build_tax_buildings }
 		position = 4
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Perm_Missions.txt
+++ b/missions/ME_Perm_Missions.txt
@@ -769,8 +769,10 @@ perm_missions_5 = {
 			num_of_owned_provinces_with = {
 				value = 5
 				OR = {
-					has_building = courthouse
-					has_building = town_hall
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+						province_has_building_of_group = { group = government all = yes }
+					}
 					has_building = university
 				}
 			}

--- a/missions/ME_Persia_Missions.txt
+++ b/missions/ME_Persia_Missions.txt
@@ -49,11 +49,14 @@ persia_missions_1 = {
 			NOT = { religion = ROOT }
 		}
 		trigger = {
-			OR = {
-				temple = 10
-				taxation_lvl_2 = 10
-				cathedral = 10
-				taxation_lvl_4 = 10
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
+				}
+				amount = 10
 			}
 			persia_region = {
 				type = all
@@ -63,12 +66,7 @@ persia_missions_1 = {
 		effect = {
 			every_owned_province = {
 				limit = {
-					OR = {
-						has_building = temple
-						has_building = taxation_lvl_2
-						has_building = cathedral
-						has_building = taxation_lvl_4
-					}
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				add_base_tax = 1
 				add_province_modifier = {

--- a/missions/ME_Poland_Missions.txt
+++ b/missions/ME_Poland_Missions.txt
@@ -528,7 +528,15 @@ me_POL_PLC_missions_2 = {
 		position = 9
 		required_missions = { rise_of_industry }
 		trigger = {
-			grand_shipyard = 1
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_grand_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = grand_shipyard }
+					}
+				}
+				amount = 1
+			}
 		}
 		effect = {
 			add_dip_power = 75

--- a/missions/ME_Poland_Missions.txt
+++ b/missions/ME_Poland_Missions.txt
@@ -199,7 +199,15 @@ me_POL_PLC_missions_1 = {
 		position = 9
 		required_missions = { rise_of_industry }
 		trigger = {
-			town_hall = 10
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_EOMAT_town_hall
+						province_has_building_of_group = { group = government equal_or_more_advanced_than = town_hall }
+					}
+				}
+				amount = 10
+			}
 		}
 		effect = {
 			add_country_modifier = {

--- a/missions/ME_Poland_Missions.txt
+++ b/missions/ME_Poland_Missions.txt
@@ -1481,11 +1481,14 @@ me_POL_PLC_missions_5 = {
 		position = 2
 		required_missions = { holy_ties }
 		trigger = {
-			OR = {
-				temple = 10
-				taxation_lvl_2 = 10
-				cathedral = 10
-				taxation_lvl_4 = 10
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
+				}
+				amount = 10
 			}
 		}
 		effect = {

--- a/missions/ME_Poland_Missions.txt
+++ b/missions/ME_Poland_Missions.txt
@@ -572,7 +572,15 @@ me_POL_PLC_missions_2 = {
 		position = 11
 		required_missions = { amber_trade }
 		trigger = {
-			stock_exchange = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_stock_exchange
+						province_has_building_of_group = { group = trade equal_or_more_advanced_than = stock_exchange }
+					}
+				}
+				amount = 5
+			}
 		}
 		effect = {
 			add_years_of_income = 4

--- a/missions/ME_Provence_Missions.txt
+++ b/missions/ME_Provence_Missions.txt
@@ -354,10 +354,7 @@ PRO_missions_5 = {
 			province_id = 201
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				AND = {
 					has_dlc = "Common Sense"
 					NOT = { development = 26 }
@@ -371,9 +368,9 @@ PRO_missions_5 = {
 		trigger = {
 			201 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				if = {
 					limit = {

--- a/missions/ME_Qir_Qoyunlu_Missions.txt
+++ b/missions/ME_Qir_Qoyunlu_Missions.txt
@@ -25,8 +25,7 @@ QIR_AKK_missions_1 = {
 				NOT = { culture = turkish }
 				AND = {
 					province_id = 418
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
+					NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				}
 			}
 		}
@@ -34,9 +33,9 @@ QIR_AKK_missions_1 = {
 			418 = { 
 				culture = turkish
 				country_or_non_sovereign_subject_holds = ROOT
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			2305 = { 
@@ -657,8 +656,7 @@ QIR_QAR_missions_1 = {
 				NOT = { culture = turkish }
 				AND = {
 					province_id = 418
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
+					NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				}
 			}
 		}
@@ -666,9 +664,9 @@ QIR_QAR_missions_1 = {
 			418 = { 
 				culture = turkish
 				country_or_non_sovereign_subject_holds = ROOT
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			2305 = { 

--- a/missions/ME_Ragusa_Missions.txt
+++ b/missions/ME_Ragusa_Missions.txt
@@ -84,10 +84,14 @@ ragusa_missions_slot_1 = {
 		required_missions = { ragusa_increase_trade }
 		position = 4
 		trigger = {
-			OR = {
-				marketplace = 4
-				trade_depot = 4
-				stock_exchange = 4
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 4
 			}
 		}
 		effect = {

--- a/missions/ME_Romania_Missions.txt
+++ b/missions/ME_Romania_Missions.txt
@@ -680,40 +680,29 @@ RMN_missions_4 = {
 			}
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			159 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			268 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 			160 = {
 				owned_by = ROOT
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Rum_Missions.txt
+++ b/missions/ME_Rum_Missions.txt
@@ -267,10 +267,7 @@ RUM_missions_slot_1 = {
 			hidden_effect = {
 				every_owned_province = {
 					limit = {
-						OR = {
-							has_building = temple
-							has_building = cathedral
-						}
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 					add_province_modifier = {
 						name = rum_imperial_growth_province_modifier
@@ -816,9 +813,9 @@ RUM_missions_slot_2 = {
 				value = 5
 				development = 30
 				has_building = university
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -1269,10 +1266,7 @@ RUM_missions_slot_4 = {
 				NOT = { is_core = ROOT }
 				NOT = { development = 20 }
 				NOT = { has_estate = estate_church }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
@@ -1280,9 +1274,9 @@ RUM_missions_slot_4 = {
 			384 = {
 				development = 20
 				has_estate = estate_church
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -1309,10 +1303,7 @@ RUM_missions_slot_4 = {
 				NOT = { is_core = ROOT }
 				NOT = { development = 20 }
 				NOT = { has_estate = estate_church }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
@@ -1320,9 +1311,9 @@ RUM_missions_slot_4 = {
 			385 = {
 				development = 20
 				has_estate = estate_church
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Rum_Missions.txt
+++ b/missions/ME_Rum_Missions.txt
@@ -1627,11 +1627,9 @@ RUM_missions_slot_5 = {
 			num_of_owned_provinces_with = {
 				value = 3
 				development = 30
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}
@@ -1649,11 +1647,9 @@ RUM_missions_slot_5 = {
 				every_owned_province = {
 					limit = {
 						development = 30
-						OR = {
-							has_building = fort_15th
-							has_building = fort_16th
-							has_building = fort_17th
-							has_building = fort_18th
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+							province_has_building_of_group = { group = defense all = yes }
 						}
 					}
 					add_province_modifier = {

--- a/missions/ME_Rum_Missions.txt
+++ b/missions/ME_Rum_Missions.txt
@@ -782,9 +782,14 @@ RUM_missions_slot_2 = {
 		trigger = {
 			stability = 1
 			NOT = { average_home_autonomy = 35 }
-			OR = {
-				courthouse = 15
-				town_hall = 15
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+						province_has_building_of_group = { group = government all = yes }
+					}
+				}
+				amount = 15
 			}
 		}
 		effect = {

--- a/missions/ME_Rum_Missions.txt
+++ b/missions/ME_Rum_Missions.txt
@@ -365,10 +365,7 @@ RUM_missions_slot_1 = {
 					}
 					OR = {
 						NOT = { development = 20 }
-						AND = {
-							NOT = { has_building = workshop }
-							NOT = { has_building = counting_house }
-						}
+						NOT = { province_has_building_of_group = { group = production all = yes } }
 					}
 				}
 			}
@@ -384,37 +381,37 @@ RUM_missions_slot_1 = {
 			}
 			358 = {
 				development = 20
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			362 = {
 				development = 20
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			363 = {
 				development = 20
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			4316 = {
 				development = 20
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 			2316 = {
 				development = 20
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}
@@ -1597,10 +1594,7 @@ RUM_missions_slot_5 = {
 			hidden_effect = {
 				every_owned_province = {
 					limit = {
-						OR = {
-							has_building = workshop
-							has_building = counting_house
-						}
+						province_has_building_of_group = { group = production all = yes }
 					}
 					add_province_modifier = {
 						name = rum_urban_production_centers_province_modifier

--- a/missions/ME_Rum_Missions.txt
+++ b/missions/ME_Rum_Missions.txt
@@ -1508,9 +1508,14 @@ RUM_missions_slot_5 = {
 		position = 7
 		required_missions = { }
 		trigger = {
-			OR = {
-				dock = 5
-				drydock = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+					}
+				}
+				amount = 5
 			}
 			OR = {
 				navy_size_percentage = 1

--- a/missions/ME_Russia_Missions.txt
+++ b/missions/ME_Russia_Missions.txt
@@ -1847,12 +1847,7 @@ me_RUS_missions_5 = {
 			}
 			every_owned_province = {
 				limit = {
-					OR = {
-						has_building = workshop
-						has_building = production_lvl_2
-						has_building = production_lvl_3
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 				}
 				add_base_production = 2
 			}

--- a/missions/ME_Russia_Missions.txt
+++ b/missions/ME_Russia_Missions.txt
@@ -1956,10 +1956,14 @@ me_RUS_missions_5 = {
 		required_missions = { russian_pride }
 		icon = mission_protect_white_sea_trade
 		trigger = {
-			OR = {
-				marketplace = 20
-				trade_depot = 20
-				stock_exchange = 20
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 20
 			}
 		}
 		effect = {

--- a/missions/ME_Ryukyu_Missions.txt
+++ b/missions/ME_Ryukyu_Missions.txt
@@ -122,16 +122,13 @@ RYU_missions_2 = {
 		required_missions = { RYU_gunpowder_era RYU_welcome_japanese_traders }
 		provinces_to_highlight = {
 			is_capital_of = ROOT
-			NOT = { has_building = marketplace }
-			NOT = { has_building = trade_depot }
-			NOT = { has_building = stock_exchange }
+			NOT = { province_has_building_of_group = { group = trade all = yes } }
 		}
 		trigger = {
 			capital_scope = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Salzburg_Missions.txt
+++ b/missions/ME_Salzburg_Missions.txt
@@ -14,18 +14,15 @@ Salzburg_missions_1 = {
 			province_id = 76
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = workshop }
-					NOT = { has_building = counting_house }
-				}
+				NOT = { province_has_building_of_group = { group = production all = yes } }
 			}
 		}
 		trigger = {
 			owns = 76
 			76 = {
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}

--- a/missions/ME_Sardinia_Missions.txt
+++ b/missions/ME_Sardinia_Missions.txt
@@ -18,26 +18,23 @@ sardinia_missions_1 = {
 			}
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			religious_unity = 1
 			127 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			2986 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Saxony_Missions.txt
+++ b/missions/ME_Saxony_Missions.txt
@@ -413,11 +413,9 @@ saxony_missions_slot_2 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Saxony_Missions.txt
+++ b/missions/ME_Saxony_Missions.txt
@@ -830,19 +830,16 @@ saxony_missions_slot_4 = {
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				NOT = { development = 25 }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			59 = {
 				country_or_non_sovereign_subject_holds = ROOT
 				development = 25
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -870,9 +867,9 @@ saxony_missions_slot_4 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = temple
-						has_building = cathedral
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Saxony_Missions.txt
+++ b/missions/ME_Saxony_Missions.txt
@@ -705,10 +705,9 @@ saxony_missions_slot_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Saxony_Missions.txt
+++ b/missions/ME_Saxony_Missions.txt
@@ -681,9 +681,9 @@ saxony_missions_slot_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Saxony_Missions.txt
+++ b/missions/ME_Saxony_Missions.txt
@@ -220,11 +220,9 @@ saxony_missions_slot_1 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = dock
-						has_building = drydock
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+						province_has_building_of_group = { group = navy all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Shimazu_Missions.txt
+++ b/missions/ME_Shimazu_Missions.txt
@@ -472,18 +472,15 @@ SMZ_missions_5 = {
 			province_id = 1012
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			1012 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Shimazu_Missions.txt
+++ b/missions/ME_Shimazu_Missions.txt
@@ -508,9 +508,9 @@ SMZ_missions_5 = {
 						trade_goods = iron
 					}
 					base_production = 5
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 			}
@@ -518,9 +518,9 @@ SMZ_missions_5 = {
 				any_owned_province = {
 					trade_goods = iron
 					base_production = 5
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 			}
@@ -539,10 +539,7 @@ SMZ_missions_5 = {
 							
 						}
 						base_production = 5
-						OR = {
-							has_building = workshop
-							has_building = counting_house
-						}
+						province_has_building_of_group = { group = production all = yes }
 					}
 					add_province_modifier = {
 						name = SMZ_excellent_weaponsmiths

--- a/missions/ME_So_Missions.txt
+++ b/missions/ME_So_Missions.txt
@@ -166,14 +166,13 @@ So_missions_2 = {
 		required_missions = { So_grand_fleet }
 		provinces_to_highlight = {
 			is_capital_of = ROOT
-			NOT = { has_building = temple }
-			NOT = { has_building = cathedral }
+			NOT = { province_has_building_of_group = { group = taxation all = yes } }
 		}
 		trigger = {
 			capital_scope = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Spain_Missions.txt
+++ b/missions/ME_Spain_Missions.txt
@@ -548,11 +548,9 @@ SPA_missions_2 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = dock
-						has_building = drydock
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_ALL
+						province_has_building_of_group = { group = navy all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Spain_Missions.txt
+++ b/missions/ME_Spain_Missions.txt
@@ -1662,10 +1662,9 @@ SPA_missions_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Spain_Missions.txt
+++ b/missions/ME_Spain_Missions.txt
@@ -524,11 +524,9 @@ SPA_missions_2 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = barracks
-						has_building = training_fields
-						has_building = regimental_camp
-						has_building = conscription_center
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Spain_Missions.txt
+++ b/missions/ME_Spain_Missions.txt
@@ -1638,9 +1638,9 @@ SPA_missions_3 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 10

--- a/missions/ME_Swabia_Missions.txt
+++ b/missions/ME_Swabia_Missions.txt
@@ -1258,23 +1258,16 @@ SWB_CON_missions_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 21 }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			1868 = {
 				owned_by = ROOT
 				development = 21
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Swabia_Missions.txt
+++ b/missions/ME_Swabia_Missions.txt
@@ -1705,19 +1705,16 @@ SWB_CON_missions_5 = {
         position = 4
 		provinces_to_highlight = {
 			owned_by = ROOT
-			NOT = { has_building = courthouse }
-			NOT = { has_building = town_hall }
-			NOT = { has_building = government_lvl_3 }
-			NOT = { has_building = government_lvl_4 }
+			NOT = { province_has_building_of_group = { group = government all = yes } }
 			NOT = { development = 18 }
 		}
 		trigger = {
 			all_owned_province = {
 				OR = {
-					has_building = courthouse
-					has_building = town_hall
-					has_building = government_lvl_3
-					has_building = government_lvl_4
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_GOVERNMENT_ALL
+						province_has_building_of_group = { group = government all = yes }
+					}
 					development = 18
 				}
 			}

--- a/missions/ME_Swabia_Missions.txt
+++ b/missions/ME_Swabia_Missions.txt
@@ -1315,23 +1315,16 @@ SWB_CON_missions_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { base_manpower = 6 }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			75 = {
 				owned_by = ROOT
 				base_manpower = 6
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}
@@ -1420,23 +1413,16 @@ SWB_CON_missions_2 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { base_manpower = 6 }
-				AND = {
-					NOT = { has_building = fort_15th }
-					NOT = { has_building = fort_16th }
-					NOT = { has_building = fort_17th }
-					NOT = { has_building = fort_18th }
-				}
+				NOT = { province_has_building_of_group = { group = defense all = yes } }
 			}
 		}
 		trigger = {
 			1872 = {
 				owned_by = ROOT
 				base_manpower = 6
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}
@@ -1457,11 +1443,9 @@ SWB_CON_missions_2 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = fort_15th
-						has_building = fort_16th
-						has_building = fort_17th
-						has_building = fort_18th
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+						province_has_building_of_group = { group = defense all = yes }
 					}
 				}
 				amount = 3

--- a/missions/ME_Sweden Missions.txt
+++ b/missions/ME_Sweden Missions.txt
@@ -15,19 +15,20 @@ SWE_missions_1 = {
 		trigger = {
 			is_at_war = no
 			manpower = 1
-			OR = {
-				regimental_camp = 15
-				conscription_center = 15
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_FORCELIMIT_ALL
+						province_has_building_of_group = { group = forcelimit all = yes }
+					}
+				}
+				amount = 15
 			}
 		}
 		effect = {
 			every_owned_province = {
 				limit = {
-					OR = {
-						has_building = forcelimit_lvl_1
-						has_building = regimental_camp
-						has_building = conscription_center
-					}
+					province_has_building_of_group = { group = forcelimit all = yes }
 				}
 				add_province_modifier = {
 					name = sweden_organizing_our_provinces_province_modifier

--- a/missions/ME_Sweden Missions.txt
+++ b/missions/ME_Sweden Missions.txt
@@ -761,21 +761,16 @@ SWE_missions_4 = {
 			province_id = 1982
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = navyforcelimit_lvl_2 }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 				has_province_modifier = sweden_snapphanarna_separatists
 			}
 		}
 		trigger = {
 			owns = 1982
 			1982 = {
-				OR = {
-					has_building = shipyard
-					has_building = navyforcelimit_lvl_2
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 				NOT = { has_province_modifier = sweden_snapphanarna_separatists }
 			}

--- a/missions/ME_Sweden Missions.txt
+++ b/missions/ME_Sweden Missions.txt
@@ -814,12 +814,7 @@ SWE_missions_5 = {
 				AND = {
 					NOT = { has_dlc = "Mandate of Heaven" }
 					OR = {
-						AND = {
-							NOT = { has_building = temple }
-							NOT = { has_building = taxation_lvl_2 }
-							NOT = { has_building = cathedral }
-							NOT = { has_building = taxation_lvl_4 }
-						}
+						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 						NOT = { province_has_building_of_group = { group = trade all = yes } }
 					}
 				}
@@ -843,12 +838,10 @@ SWE_missions_5 = {
 			}
 			else = {
 				4163 = {
-					OR = {
-						has_building = temple
-						has_building = taxation_lvl_2
-						has_building = cathedral
-						has_building = taxation_lvl_4
-					}
+					custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
+				}
 					custom_trigger_tooltip = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 						province_has_building_of_group = { group = trade all = yes }

--- a/missions/ME_Sweden Missions.txt
+++ b/missions/ME_Sweden Missions.txt
@@ -318,22 +318,15 @@ SWE_missions_2 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { is_core = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
 			owns_core_province = 45
 			45 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}
@@ -827,12 +820,7 @@ SWE_missions_5 = {
 							NOT = { has_building = cathedral }
 							NOT = { has_building = taxation_lvl_4 }
 						}
-						AND = {
-							NOT = { has_building = marketplace }
-							NOT = { has_building = trade_lvl_2 }
-							NOT = { has_building = trade_depot }
-							NOT = { has_building = stock_exchange }
-						}
+						NOT = { province_has_building_of_group = { group = trade all = yes } }
 					}
 				}
 			}
@@ -861,11 +849,9 @@ SWE_missions_5 = {
 						has_building = cathedral
 						has_building = taxation_lvl_4
 					}
-					OR = {
-						has_building = marketplace
-						has_building = trade_lvl_2
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
 					}
 				}
 			}

--- a/missions/ME_Takeda_Missions.txt
+++ b/missions/ME_Takeda_Missions.txt
@@ -388,10 +388,7 @@ TKD_missions_4 = {
 					NOT = { has_dlc = "Mandate of Heaven" }
 					OR = {
 						NOT = { province_has_building_of_group = { group = taxation all = yes } }
-						AND = {
-							NOT = { has_building = workshop }
-							NOT = { has_building = counting_house }
-						}
+						NOT = { province_has_building_of_group = { group = production all = yes } }
 					}
 				}
 			}
@@ -419,9 +416,9 @@ TKD_missions_4 = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 						province_has_building_of_group = { group = taxation all = yes }
 					}
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 			}

--- a/missions/ME_Takeda_Missions.txt
+++ b/missions/ME_Takeda_Missions.txt
@@ -387,10 +387,7 @@ TKD_missions_4 = {
 				AND = {
 					NOT = { has_dlc = "Mandate of Heaven" }
 					OR = {
-						AND = {
-							NOT = { has_building = temple }
-							NOT = { has_building = cathedral }
-						}
+						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 						AND = {
 							NOT = { has_building = workshop }
 							NOT = { has_building = counting_house }
@@ -418,9 +415,9 @@ TKD_missions_4 = {
 			}
 			else = {
 				1029 = {
-					OR = {
-						has_building = temple
-						has_building = cathedral
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 					OR = {
 						has_building = workshop

--- a/missions/ME_Teutonic_Order_Missions.txt
+++ b/missions/ME_Teutonic_Order_Missions.txt
@@ -192,12 +192,7 @@ TEU_missions_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { development = 16 }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
@@ -207,11 +202,9 @@ TEU_missions_1 = {
 			41 = {
 				owned_by = ROOT
 				development = 16
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
@@ -221,11 +214,9 @@ TEU_missions_1 = {
 			43 = {
 				owned_by = ROOT
 				development = 16
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
@@ -737,12 +728,7 @@ TEU_missions_4 = {
 			province_id = 43
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
@@ -758,11 +744,9 @@ TEU_missions_4 = {
 			}
 			43 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_Teutonic_Order_Missions.txt
+++ b/missions/ME_Teutonic_Order_Missions.txt
@@ -198,12 +198,7 @@ TEU_missions_1 = {
 					NOT = { has_building = cathedral }
 					NOT = { has_building = taxation_lvl_4 }
 				}
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
@@ -218,11 +213,9 @@ TEU_missions_1 = {
 					has_building = cathedral
 					has_building = taxation_lvl_4
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			43 = {
@@ -234,11 +227,9 @@ TEU_missions_1 = {
 					has_building = cathedral
 					has_building = taxation_lvl_4
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}
@@ -268,12 +259,7 @@ TEU_missions_1 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { base_production = 10 }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
@@ -281,11 +267,9 @@ TEU_missions_1 = {
 			40 = {
 				owned_by = ROOT
 				base_production = 10
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2 
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}
@@ -759,12 +743,7 @@ TEU_missions_4 = {
 					NOT = { has_building = cathedral }
 					NOT = { has_building = taxation_lvl_4 }
 				}
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
@@ -785,11 +764,9 @@ TEU_missions_4 = {
 					has_building = cathedral
 					has_building = taxation_lvl_4
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Theodoro_Missions.txt
+++ b/missions/ME_Theodoro_Missions.txt
@@ -325,10 +325,14 @@ theodoro_missions_column_5 = {
 		required_missions = { }
 		position = 1
 		trigger = {
-			OR = {
-				marketplace = 5
-				trade_depot = 5
-				stock_exchange = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Thuringia_Missions.txt
+++ b/missions/ME_Thuringia_Missions.txt
@@ -283,19 +283,16 @@ THU_missions_3 = {
 			OR = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				NOT = { development = 25 }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = cathedral }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			59 = {
 				country_or_non_sovereign_subject_holds = ROOT
 				development = 25
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Timurids_Missions.txt
+++ b/missions/ME_Timurids_Missions.txt
@@ -410,9 +410,9 @@ TIM_missions_2 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					OR = {
-						has_building = temple
-						has_building = cathedral
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 				}
 				amount = 15
@@ -925,9 +925,9 @@ TIM_missions_3 = {
 			calc_true_if = {
 				all_owned_province = {
 					development = 30
-					OR = {
-						has_building = temple
-						has_building = cathedral
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 					OR = {
 						has_building = workshop
@@ -1148,10 +1148,7 @@ TIM_missions_5 = {
 					province_id = 454
 					OR = {
 						NOT = { owned_by = ROOT }
-						AND = {
-							NOT = { has_building = temple }
-							NOT = { has_building = cathedral }
-						}
+						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 						AND = {
 							NOT = { has_dlc = "Mandate of Heaven" }
 							NOT = { has_building = workshop }
@@ -1173,9 +1170,9 @@ TIM_missions_5 = {
 		trigger = {
 			446 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			if = {

--- a/missions/ME_Timurids_Missions.txt
+++ b/missions/ME_Timurids_Missions.txt
@@ -929,9 +929,9 @@ TIM_missions_3 = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 						province_has_building_of_group = { group = taxation all = yes }
 					}
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 				amount = 5
@@ -1151,8 +1151,7 @@ TIM_missions_5 = {
 						NOT = { province_has_building_of_group = { group = taxation all = yes } }
 						AND = {
 							NOT = { has_dlc = "Mandate of Heaven" }
-							NOT = { has_building = workshop }
-							NOT = { has_building = counting_house }
+							NOT = { province_has_building_of_group = { group = production all = yes } }
 						}
 					}
 				}
@@ -1191,9 +1190,9 @@ TIM_missions_5 = {
 			}
 			else = {
 				446 = {
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
 				}
 			}

--- a/missions/ME_Transoxiana_Missions.txt
+++ b/missions/ME_Transoxiana_Missions.txt
@@ -126,10 +126,9 @@ Transoxiana_missions_slot_2 = {
 		trigger = {
 			454 = {
 				development = 30
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 				trade_share = {
 					country = ROOT

--- a/missions/ME_Trebizond_Missions.txt
+++ b/missions/ME_Trebizond_Missions.txt
@@ -208,10 +208,9 @@ TRE_Missions_1 = {
 				value = 3
 			}
 			330 = {
-				OR = {
-					has_building = marketplace
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Trebizond_Missions.txt
+++ b/missions/ME_Trebizond_Missions.txt
@@ -355,9 +355,9 @@ TRE_Missions_2 = {
 			else = {
 				patriarch_authority = 0.1
 				capital_scope = {
-					OR = {
-						has_building = temple
-						has_building = cathedral
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
 					}
 				}
 			}

--- a/missions/ME_Uesugi_Missions.txt
+++ b/missions/ME_Uesugi_Missions.txt
@@ -200,8 +200,15 @@ UES_missions_2 = {
 		position = 4
 		trigger = {
 			OR = {
-				shipyard = 5
-				grand_shipyard = 5
+				calc_true_if = {
+					all_owned_province = {
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+							province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
+						}
+					}
+				amount = 5
+				}
 				exploration_ideas = 4
 			}
 			OR = {

--- a/missions/ME_Ulm_Missions.txt
+++ b/missions/ME_Ulm_Missions.txt
@@ -276,12 +276,7 @@ Ulm_missions_3 = {
 			province_id = 1872
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {

--- a/missions/ME_United_Kingdoms_Missions.txt
+++ b/missions/ME_United_Kingdoms_Missions.txt
@@ -990,20 +990,15 @@ UKS_missions_1 = {
 			province_id = 170
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = dock }
-					NOT = { has_building = navymanpower_lvl_2 }
-					NOT = { has_building = drydock }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 			}
 		}
         trigger = {
 			170 = {
 				owned_by = ROOT
-				OR = {
-					has_building = dock
-					has_building = navyforcelimit_lvl_2
-					has_building = drydock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
 			}
 		}
@@ -3706,21 +3701,16 @@ UKS_missions_5 = {
 					NOT = { has_building = navyforcelimit_lvl_2 }
 					NOT = { has_building = grand_shipyard }
 				}
-				AND = {
-					NOT = { has_building = dock }
-					NOT = { has_building = navymanpower_lvl_2 }
-					NOT = { has_building = drydock }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 			}
 		}
         trigger = {
 			galley_fraction = 0.1
 			201 = {
 				owned_by = ROOT
-				OR = {
-					has_building = dock
-					has_building = navymanpower_lvl_2
-					has_building = drydock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
 				OR = {
 					has_building = shipyard

--- a/missions/ME_United_Kingdoms_Missions.txt
+++ b/missions/ME_United_Kingdoms_Missions.txt
@@ -1114,12 +1114,7 @@ UKS_missions_1 = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				is_city = no
 				NOT = { development = 12 }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
         trigger = {
@@ -1127,11 +1122,9 @@ UKS_missions_1 = {
 				country_or_non_sovereign_subject_holds = ROOT
 				is_city = yes
 				development = 12
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}
@@ -1496,12 +1489,7 @@ UKS_missions_2 = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				is_city = no
 				NOT = { development = 12 }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
         trigger = {
@@ -1509,11 +1497,9 @@ UKS_missions_2 = {
 				country_or_non_sovereign_subject_holds = ROOT
 				is_city = yes
 				development = 12
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}
@@ -3107,12 +3093,7 @@ UKS_missions_4 = {
 			province_id = 201
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
         trigger = {
@@ -3135,11 +3116,9 @@ UKS_missions_4 = {
 			light_ship_fraction = 0.25
 			201 = {
 				owned_by = ROOT
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}
@@ -3373,12 +3352,7 @@ UKS_missions_5 = {
 								NOT = { province_has_center_of_trade_of_level = 1 }
 								AND = {
 									owned_by = ROOT
-									OR = {
-										has_building = marketplace
-										has_building = trade_lvl_2
-										has_building = trade_depot
-										has_building = stock_exchange
-									}
+									province_has_building_of_group = { group = trade all = yes }
 								}
 							}
 						}

--- a/missions/ME_United_Kingdoms_Missions.txt
+++ b/missions/ME_United_Kingdoms_Missions.txt
@@ -1153,12 +1153,7 @@ UKS_missions_1 = {
 				is_city = no
 				NOT = { development = 12 }
 				NOT = { religion = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
         trigger = {
@@ -1167,11 +1162,9 @@ UKS_missions_1 = {
 				is_city = yes
 				development = 12
 				religion = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}
@@ -1588,12 +1581,7 @@ UKS_missions_2 = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				is_city = no
 				NOT = { development = 12 }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
         trigger = {
@@ -1601,11 +1589,9 @@ UKS_missions_2 = {
 				country_or_non_sovereign_subject_holds = ROOT
 				is_city = yes
 				development = 12
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_United_Kingdoms_Missions.txt
+++ b/missions/ME_United_Kingdoms_Missions.txt
@@ -1243,28 +1243,22 @@ UKS_missions_2 = {
 			}
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = navyforcelimit_lvl_2 }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 			}
 		}
         trigger = {
 			4373 = {
 				owned_by = ROOT
-				OR = {
-					has_building = shipyard
-					has_building = navyforcelimit_lvl_2
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 			}
 			234 = {
 				owned_by = ROOT
-				OR = {
-					has_building = shipyard
-					has_building = navyforcelimit_lvl_2
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 			}
 		}
@@ -1515,11 +1509,7 @@ UKS_missions_2 = {
 				NOT = { country_or_non_sovereign_subject_holds = ROOT }
 				is_city = no
 				NOT = { development = 12 }
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = navyforcelimit_lvl_2 }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 			}
 		}
         trigger = {
@@ -1527,10 +1517,9 @@ UKS_missions_2 = {
 				country_or_non_sovereign_subject_holds = ROOT
 				is_city = yes
 				development = 12
-				OR = {
-					has_building = shipyard
-					has_building = navyforcelimit_lvl_2
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 			}
 		}
@@ -3696,11 +3685,7 @@ UKS_missions_5 = {
 			province_id = 201
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = shipyard }
-					NOT = { has_building = navyforcelimit_lvl_2 }
-					NOT = { has_building = grand_shipyard }
-				}
+				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard } }
 				NOT = { province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock } }
 			}
 		}
@@ -3712,10 +3697,9 @@ UKS_missions_5 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
 					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
-				OR = {
-					has_building = shipyard
-					has_building = navyforcelimit_lvl_2
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 			}
 		}

--- a/missions/ME_Utrecht_Missions.txt
+++ b/missions/ME_Utrecht_Missions.txt
@@ -55,12 +55,14 @@ utrecht_missions_1 = {
 		position = 3
 		required_missions = { utr_control_the_dikes }
 		trigger = {
-			total_development = 30
-			OR = {
-				temple = 1
- 				taxation_lvl_2 = 1
-				cathedral = 1
-				taxation_lvl_4 = 1
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
+				}
+				amount = 1
 			}
 		}
 		effect = {

--- a/missions/ME_Venice_Missions.txt
+++ b/missions/ME_Venice_Missions.txt
@@ -773,12 +773,7 @@ VEN_missions_4 = {
 					OR = {
 						NOT = { owned_by = ROOT }
 						NOT = { development = 10 }
-						AND = {
-							NOT = { has_building = marketplace }
-							NOT = { has_building = trade_lvl_2 }
-							NOT = { has_building = trade_depot }
-							NOT = { has_building = stock_exchange }
-						}
+						NOT = { province_has_building_of_group = { group = trade all = yes } }
 					}
 				}
 				AND = {
@@ -786,12 +781,7 @@ VEN_missions_4 = {
 					OR = {
 						NOT = { owned_by = ROOT }
 						NOT = { development = 25 }
-						AND = {
-							NOT = { has_building = marketplace }
-							NOT = { has_building = trade_lvl_2 }
-							NOT = { has_building = trade_depot }
-							NOT = { has_building = stock_exchange }
-						}
+						NOT = { province_has_building_of_group = { group = trade all = yes } }
 					}
 				}
 			}
@@ -802,29 +792,23 @@ VEN_missions_4 = {
 			owns = 130
 			4174 = {
 				development = 10
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			108 = {
 				development = 25
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 			130 = {
 				development = 10
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}
@@ -952,12 +936,7 @@ VEN_missions_5 = {
 					NOT = { has_building = cathedral }
 					NOT = { has_building = taxation_lvl_4 }
 				}
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		trigger = {
@@ -971,11 +950,9 @@ VEN_missions_5 = {
 					has_building = cathedral
 					has_building = taxation_lvl_4
 				}
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
 		}

--- a/missions/ME_Venice_Missions.txt
+++ b/missions/ME_Venice_Missions.txt
@@ -861,9 +861,14 @@ VEN_missions_4 = {
 		position = 8
 		trigger = {
 			navy_size = 40
-			OR = {
-				shipyard = 5
-				grand_shipyard = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
+					}
+				}
+				amount = 5
 			}
 			calc_true_if = {
 				all_owned_province = {

--- a/missions/ME_Venice_Missions.txt
+++ b/missions/ME_Venice_Missions.txt
@@ -930,12 +930,7 @@ VEN_missions_5 = {
 			province_id = 112
 			OR = {
 				NOT = { is_capital_of = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
@@ -944,11 +939,9 @@ VEN_missions_5 = {
 			monthly_income = 25
 			capital = 112
 			112 = {
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				custom_trigger_tooltip = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL

--- a/missions/ME_Venice_Missions.txt
+++ b/missions/ME_Venice_Missions.txt
@@ -865,9 +865,14 @@ VEN_missions_4 = {
 				shipyard = 5
 				grand_shipyard = 5
 			}
-			OR = {
-				dock = 5
-				drydock = 5
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+					}
+				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Wales_Braelyc_Cymru_Missions.txt
+++ b/missions/ME_Wales_Braelyc_Cymru_Missions.txt
@@ -1230,12 +1230,7 @@ WLS_missions_4 = {
 			OR = {
 				NOT = { owned_by = ROOT }
 				NOT = { base_production = 15 }
-				AND = {
-					NOT = { has_building = marketplace }
-					NOT = { has_building = trade_lvl_2 }
-					NOT = { has_building = trade_depot }
-					NOT = { has_building = stock_exchange }
-				}
+				NOT = { province_has_building_of_group = { group = trade all = yes } }
 			}
 		}
 		position = 7
@@ -1243,14 +1238,11 @@ WLS_missions_4 = {
 			236 = {
 				owned_by = ROOT
 				base_production = 15
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
 				}
 			}
-			
 		}
 		effect = {
 			236 = {

--- a/missions/ME_Wales_Braelyc_Cymru_Missions.txt
+++ b/missions/ME_Wales_Braelyc_Cymru_Missions.txt
@@ -609,6 +609,7 @@ WLS_CYR_BRL_missions_4 = {
 				AND = {
 					is_capital_of = ROOT
 					NOT = { has_building = government_lvl_3 }
+					NOT = { has_building = government_lvl_4 }
 				}
 			}
 		}
@@ -618,7 +619,10 @@ WLS_CYR_BRL_missions_4 = {
 				culture = english
 			}
 			capital_scope = {
-				has_building = government_lvl_3
+				OR = {
+					has_building = government_lvl_3
+					has_building = government_lvl_4
+				}
 			}
 			if = {
 				limit = {

--- a/missions/ME_Wurttemberg_Missions.txt
+++ b/missions/ME_Wurttemberg_Missions.txt
@@ -71,11 +71,14 @@ WUR_missions_5 = {
 	wur_build_churches = {
 		icon = mission_european_church
 		trigger = {
-			OR = {
-				temple = 2
-				taxation_lvl_2 = 2
-				cathedral = 2
-				taxation_lvl_4 = 2
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
+				}
+				amount = 2
 			}
 		}
 		effect = {

--- a/missions/ME_Wurzburg_Missions.txt
+++ b/missions/ME_Wurzburg_Missions.txt
@@ -99,22 +99,15 @@ WBG_missions_5 = {
 			province_id = 79
 			OR = {
 				NOT = { owned_by = ROOT }
-				AND = {
-					NOT = { has_building = temple }
-					NOT = { has_building = taxation_lvl_2 }
-					NOT = { has_building = cathedral }
-					NOT = { has_building = taxation_lvl_4 }
-				}
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			79 = {
 				owned_by = ROOT
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/ME_Yaroslavl_Missions.txt
+++ b/missions/ME_Yaroslavl_Missions.txt
@@ -224,16 +224,14 @@ yaroslavl_missions_2 = {
 		required_missions = { yaroslavl_army }
 		position = 7
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = manpower_lvl_1
-					has_building = barracks
-					has_building = training_fields
-					has_building = forcelimit_lvl_1
-					has_building = regimental_camp
-					has_building = conscription_center
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_ARMY_ALL
+						province_has_building_of_group = { group = army all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Yaroslavl_Missions.txt
+++ b/missions/ME_Yaroslavl_Missions.txt
@@ -896,14 +896,14 @@ yaroslavl_missions_5 = {
 		required_missions = { yaroslavl_foritfy_yaroslavl }
 		position = 5
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Yaroslavl_Missions.txt
+++ b/missions/ME_Yaroslavl_Missions.txt
@@ -874,11 +874,9 @@ yaroslavl_missions_5 = {
 		trigger = {
 			owns_core_province = 308
 			308 = {
-				OR = {
-					has_building = fort_15th
-					has_building = fort_16th
-					has_building = fort_17th
-					has_building = fort_18th
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_DEFENSE_ALL
+					province_has_building_of_group = { group = defense all = yes }
 				}
 			}
 		}

--- a/missions/ME_Yaroslavl_Missions.txt
+++ b/missions/ME_Yaroslavl_Missions.txt
@@ -920,14 +920,14 @@ yaroslavl_missions_5 = {
 		required_missions = { yaroslavl_build_religion_buildings }
 		position = 6
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = marketplace
-					has_building = trade_lvl_2
-					has_building = trade_depot
-					has_building = stock_exchange
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Yaroslavl_Missions.txt
+++ b/missions/ME_Yaroslavl_Missions.txt
@@ -633,14 +633,14 @@ yaroslavl_missions_4 = {
 		required_missions = { yaroslavl_build_religion_buildings }
 		position = 6
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 5
-				OR = {
-					has_building = workshop
-					has_building = production_lvl_2
-					has_building = production_lvl_3
-					has_building = counting_house
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
+					}
 				}
+				amount = 5
 			}
 		}
 		effect = {

--- a/missions/ME_Zapadoslavia_Missions.txt
+++ b/missions/ME_Zapadoslavia_Missions.txt
@@ -14,11 +14,11 @@ ZCV_missions_1 = {
 		trigger = {
 			calc_true_if = {
 				all_owned_province = {
-					culture_group = ROOT
-					OR = {
-						has_building = workshop
-						has_building = counting_house
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+						province_has_building_of_group = { group = production all = yes }
 					}
+					culture_group = ROOT
 				}
 				amount = 20
 			}
@@ -27,10 +27,7 @@ ZCV_missions_1 = {
 			random_owned_province = {
 				limit = {
 					culture_group = ROOT
-					OR = {
-						has_building = workshop
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 				}
 				add_base_manpower = 1
 				add_base_tax = 1
@@ -38,10 +35,7 @@ ZCV_missions_1 = {
 			random_owned_province = {
 				limit = {
 					culture_group = ROOT
-					OR = {
-						has_building = workshop
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 				}
 				add_base_manpower = 1
 				add_base_tax = 1
@@ -49,10 +43,7 @@ ZCV_missions_1 = {
 			random_owned_province = {
 				limit = {
 					culture_group = ROOT
-					OR = {
-						has_building = workshop
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 				}
 				add_base_manpower = 1
 				add_base_tax = 1
@@ -60,10 +51,7 @@ ZCV_missions_1 = {
 			random_owned_province = {
 				limit = {
 					culture_group = ROOT
-					OR = {
-						has_building = workshop
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 				}
 				add_base_manpower = 1
 				add_base_tax = 1
@@ -71,10 +59,7 @@ ZCV_missions_1 = {
 			random_owned_province = {
 				limit = {
 					culture_group = ROOT
-					OR = {
-						has_building = workshop
-						has_building = counting_house
-					}
+					province_has_building_of_group = { group = production all = yes }
 				}
 				add_base_manpower = 1
 				add_base_tax = 1

--- a/missions/Mamluk_Missions.txt
+++ b/missions/Mamluk_Missions.txt
@@ -136,7 +136,10 @@ mam_north_missions = {
 			OR = {
 				trade_embargoing = VEN
 				358 = {
-					has_building = marketplace
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
 				}
 			}
 		}

--- a/missions/Manchu_Missions.txt
+++ b/missions/Manchu_Missions.txt
@@ -28,15 +28,15 @@ manchu_missions_1 = {
 			province_id = 4201
 			OR = {
 				NOT = { owned_by = ROOT is_core = ROOT }
-				NOT = { has_building = temple }
+				NOT = { province_has_building_of_group = { group = taxation all = yes } }
 			}
 		}
 		trigger = {
 			owns_core_province = 4201
 			4201 = {
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 		}

--- a/missions/Pirate_Missions.txt
+++ b/missions/Pirate_Missions.txt
@@ -62,13 +62,14 @@ pirate_1 = {
 				}
 			}
 			else = {
-				num_of_owned_provinces_with = {
-					OR = {
-						has_building = marketplace
-						has_building = trade_depot
-						has_building = stock_exchange
+				calc_true_if = {
+					all_owned_province = {
+						custom_trigger_tooltip = {
+							tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+							province_has_building_of_group = { group = trade all = yes }
+						}
 					}
-					value = 5
+					amount = 5
 				}
 			}
 		}

--- a/missions/Polish_Missions.txt
+++ b/missions/Polish_Missions.txt
@@ -221,9 +221,9 @@ plc_missions_1 = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
 						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 					}
-					OR = {
-						has_building = shipyard
-						has_building = grand_shipyard
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 					}
 				}
 			}
@@ -235,9 +235,9 @@ plc_missions_1 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
 					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
-				OR = {
-					has_building = shipyard
-					has_building = grand_shipyard
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_shipyard
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = shipyard }
 				}
 			}
 			naval_forcelimit = 20

--- a/missions/Polish_Missions.txt
+++ b/missions/Polish_Missions.txt
@@ -217,9 +217,9 @@ plc_missions_1 = {
 			NOT = {
 				AND = {
 					owned_by = ROOT
-					OR = {
-						has_building = dock
-						has_building = drydock
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 					}
 					OR = {
 						has_building = shipyard
@@ -231,9 +231,9 @@ plc_missions_1 = {
 		trigger = {
 			43 = {
 				owned_by = ROOT
-				OR = {
-					has_building = dock
-					has_building = drydock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
 				}
 				OR = {
 					has_building = shipyard

--- a/missions/Polish_Missions.txt
+++ b/missions/Polish_Missions.txt
@@ -796,9 +796,9 @@ polish_missions_slot_5 = {
 				owned_by = ROOT
 				NOT = { unrest = 1 }
 				NOT = { devastation = 1 }
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 				if = {
 					limit = {

--- a/missions/Polish_Missions.txt
+++ b/missions/Polish_Missions.txt
@@ -807,9 +807,9 @@ polish_missions_slot_5 = {
 					province_has_center_of_trade_of_level = 3
 				}
 				else = {
-					OR = {
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_trade_depot
+						province_has_building_of_group = { group = trade equal_or_more_advanced_than = trade_depot }
 					}
 				}
 			}
@@ -875,11 +875,11 @@ polish_missions_slot_5 = {
 					province_has_center_of_trade_of_level = 3
 				}
 				else = {
-					OR = {
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_trade_depot
+						province_has_building_of_group = { group = trade equal_or_more_advanced_than = trade_depot }
 					}
-				}				
+				}
 			}
 			2961 = {
 				development = 20
@@ -891,11 +891,11 @@ polish_missions_slot_5 = {
 					province_has_center_of_trade_of_level = 2
 				}
 				else = {
-					OR = {
-						has_building = trade_depot
-						has_building = stock_exchange
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_EOMAT_trade_depot
+						province_has_building_of_group = { group = trade equal_or_more_advanced_than = trade_depot }
 					}
-				}	
+				}
 			}
 		}
 		effect = {

--- a/missions/RB_Scottish_Missions.txt
+++ b/missions/RB_Scottish_Missions.txt
@@ -512,9 +512,14 @@ sco_rb_colonial = {
 			1975 = {
 				is_strongest_trade_power = ROOT
 			}
-			num_of_owned_provinces_with = {
-				has_building = marketplace
-				value = 2
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
+				}
+				amount = 2
 			}
 			num_of_light_ship = 10
 		}

--- a/missions/Romanian_Missions.txt
+++ b/missions/Romanian_Missions.txt
@@ -299,9 +299,9 @@ romanian_missions_5 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
 					province_has_building_of_group = { group = taxation all = yes }
 				}
-				OR = {
-					has_building = workshop
-					has_building = counting_house
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_PRODUCTION_ALL
+					province_has_building_of_group = { group = production all = yes }
 				}
 			}
 		}

--- a/missions/Romanian_Missions.txt
+++ b/missions/Romanian_Missions.txt
@@ -295,9 +295,9 @@ romanian_missions_5 = {
 				owned_by = ROOT
 				NOT = { devastation = 1 }
 				NOT = { unrest = 1 }
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 				OR = {
 					has_building = workshop

--- a/missions/TR_Novgorodian_Missions.txt
+++ b/missions/TR_Novgorodian_Missions.txt
@@ -376,7 +376,10 @@ tr_novgorod_3 = {
 					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 					province_has_building_of_group = { group = trade all = yes }
 				}
-				has_building = dock
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+					province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+				}
 				is_strongest_trade_power = ROOT
 			}
 			navy_size_percentage = 1
@@ -605,7 +608,10 @@ tr_novgorod_4 = {
 						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
 						province_has_building_of_group = { group = trade all = yes }
 					}
-					has_building = dock
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_NAVY_EOMAT_dock
+						province_has_building_of_group = { group = navy equal_or_more_advanced_than = dock }
+				}
 				}
 			}
 		}

--- a/missions/TR_Novgorodian_Missions.txt
+++ b/missions/TR_Novgorodian_Missions.txt
@@ -372,7 +372,10 @@ tr_novgorod_3 = {
 		trigger = {
 			33 = {
 				owned_by = ROOT
-				has_building = marketplace
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+					province_has_building_of_group = { group = trade all = yes }
+				}
 				has_building = dock
 				is_strongest_trade_power = ROOT
 			}
@@ -598,7 +601,10 @@ tr_novgorod_4 = {
 			owns = 1955
 			1955 = {
 				OR = {
-					has_building = marketplace
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TRADE_ALL
+						province_has_building_of_group = { group = trade all = yes }
+					}
 					has_building = dock
 				}
 			}

--- a/missions/TR_Novgorodian_Missions.txt
+++ b/missions/TR_Novgorodian_Missions.txt
@@ -854,9 +854,9 @@ tr_novgorod_5 = {
 			310 = {
 				owned_by = ROOT
 				has_state_patriach = yes
-				OR = {
-					has_building = temple
-					has_building = cathedral
+				custom_trigger_tooltip = {
+					tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+					province_has_building_of_group = { group = taxation all = yes }
 				}
 			}
 			OR = {
@@ -881,7 +881,15 @@ tr_novgorod_5 = {
 		provinces_to_highlight = {
 		}
 		trigger = {
-			cathedral = 10
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_EOMAT_cathedral
+						province_has_building_of_group = { group = taxation equal_or_more_advanced_than = cathedral }
+					}
+				}
+				amount = 10
+			}
 			religious_unity = 1
 		}
 		effect = {

--- a/missions/TR_Russian_missions.txt
+++ b/missions/TR_Russian_missions.txt
@@ -22,14 +22,14 @@ tr_russia_religious_missions = {
 		provinces_to_highlight = {
 		}
 		trigger = {
-			num_of_owned_provinces_with = {
-				value = 20
-				OR = {
-					has_building = temple
-					has_building = taxation_lvl_2
-					has_building = cathedral
-					has_building = taxation_lvl_4
+			calc_true_if = {
+				all_owned_province = {
+					custom_trigger_tooltip = {
+						tooltip = PROVINCE_HAS_BUILDING_OF_GROUP_TAXATION_ALL
+						province_has_building_of_group = { group = taxation all = yes }
+					}
 				}
+				amount = 20
 			}
 		}
 		effect = {

--- a/missions/Tatar_Missions.txt
+++ b/missions/Tatar_Missions.txt
@@ -305,11 +305,7 @@ tatar_missions_1 = {
 							region = central_asia_region
 							region = khorasan_region
 						}
-						OR = {
-							has_building = marketplace
-							has_building = trade_depot
-							has_building = stock_exchange
-						}
+						province_has_building_of_group = { group = trade all = yes }
 						value = 8
 					}
 				}


### PR DESCRIPTION
Finished project #82 

I added forcelimit and manpower options to the `province_has_building_of_group` function.
I believe that every trigger and highlight in missions now uses this function to determine building status.
Most were pretty standard cases, I had to add a custom tooltip twice I think.
In general this fixes a lot of bugs where the new buildings of higher tier would not count as credit for a mission, and logic errors where you had to have EITHER 10 temples or 10 cathedrals, not a mix of these.