### PR TITLE
AI rebate decision

### DIFF
--- a/common/static_modifiers/AI.txt
+++ b/common/static_modifiers/AI.txt
@@ -1,8 +1,8 @@
-ai_nation = {
-	diplomats = 1							# ai has to reserve a diplomat for short term action so it gets an extra to put it on equal footing with player
-	free_leader_pool = 50					# temporary fix, AI is ignoring Free Leader limit during the war
-	sailors_recovery_speed = 0.25		
-}
+#ai_nation = {
+#	diplomats = 1							# ai has to reserve a diplomat for short term action so it gets an extra to put it on equal footing with player
+#	free_leader_pool = 1					# temporary fix, AI is ignoring Free Leader limit during the war
+#	sailors_recovery_speed = 0.25		
+#}
 
 
 difficulty_hard_ai = {

--- a/decisions/AIExplorerRebate.txt
+++ b/decisions/AIExplorerRebate.txt
@@ -4,9 +4,9 @@ country_decisions = {
         potential = {
             ai = yes
             OR = {
-                num_of_conquistadors = 2
+                num_of_conquistadors = 1
                 num_of_admirals = 2
-                num_of_explorers = 2
+                num_of_explorers = 1
             }
         }
         allow = {

--- a/decisions/AIExplorerRebate.txt
+++ b/decisions/AIExplorerRebate.txt
@@ -1,0 +1,57 @@
+country_decisions = { 
+    explorer_rebate ={
+        major = yes
+        potential = {
+            ai = yes
+            OR = {
+                num_of_conquistadors = 2
+                num_of_admirals = 2
+                num_of_explorers = 2
+            }
+        }
+        allow = {
+            OR = {
+                NOT = { has_country_flag = expRebate }
+                had_country_flag = {
+                    flag = expRebate
+                    days = 365
+                }
+            }
+        }
+        effect = {
+            clr_country_flag = expRebate
+            
+            export_to_variable = { which = numGen value = trigger_value:num_of_generals      }
+			export_to_variable = { which = numCon value = trigger_value:num_of_conquistadors }
+            export_to_variable = { which = numAdm value = trigger_value:num_of_admirals      }
+            export_to_variable = { which = numExp value = trigger_value:num_of_explorers     }
+            export_to_variable = { which = numFLP value = modifier:free_leader_pool          }
+            log = "[Root.GetName] [Root.numGen.GetValue] [Root.numCon.GetValue] [Root.numAdm.GetValue] [Root.numExp.GetValue] [Root.numFLP.GetValue]"
+
+              change_variable = { which = numGen which = numCon }
+              change_variable = { which = numGen which = numAdm }
+              change_variable = { which = numGen which = numExp }
+            subtract_variable = { which = numGen value = 4      } #-4 for each category
+            if = { limit = { is_monarch_leader = yes } subtract_variable = { which = numGen value = 1 } }
+            if = { limit = {    is_heir_leader = yes } subtract_variable = { which = numGen value = 1 } }
+            log = "[Root.GetName]: [Root.numGen.GetValue] - [Root.numFLP.GetValue]"
+            subtract_variable = { which = numFLP which = numGen }
+
+                 if = { limit = { NOT = { check_variable = { which = numFLP value = -4 } } } add_mil_power = 60 log = "60" }
+            else_if = { limit = { NOT = { check_variable = { which = numFLP value = -3 } } } add_mil_power = 48 log = "48" }
+            else_if = { limit = { NOT = { check_variable = { which = numFLP value = -2 } } } add_mil_power = 36 log = "36" }
+            else_if = { limit = { NOT = { check_variable = { which = numFLP value = -1 } } } add_mil_power = 24 log = "24" }
+            else_if = { limit = { NOT = { check_variable = { which = numFLP value =  0 } } } add_mil_power = 12 log = "12" }
+            set_country_flag = expRebate
+        }
+        ai_will_do = {
+            factor = 1
+        }
+    }
+}
+
+#num_of_generals
+#num_of_conquistadors
+#num_of_admirals
+#num_of_explorers
+#free_leader_pool


### PR DESCRIPTION
Rebates the AI for being over the leader limit. AI is currently bugged to consider only generals when rolling to leader limit.

The num_of_X conditionals for the generals/admirals/conquistadors/explorers are bugged. The count starts at 1 instead of 0.

It seems like the game uses num_of_generals to determine if can roll for another general and doesn't consider admirals/conquistadors/explorers.

The num_of_generals conditional also counts free leaders from ruler/heir.

I couldn't think of a better way for the AI to get their points back since there is no monthly monarch point gain function that I could find.