### PR TITLE
TGE Should only fire once

### DIFF
--- a/events/TGE_new_goods.txt
+++ b/events/TGE_new_goods.txt
@@ -10,6 +10,7 @@ country_event = {
 	desc = "new_goods.1"
 	picture = BIG_BOOK_eventPicture_cute   #### überprüfen
 	is_triggered_only = yes
+	fire_only_once = yes
 	hidden = yes
 	trigger = {
 		ai = no


### PR DESCRIPTION
The event should only fire once, otherwise the on_action makes it activate every single load time, resetting all the trade goods resulting in the built stuff being removed.